### PR TITLE
Fix URL normalization for ssh:// prefixed Git URLs

### DIFF
--- a/internal/url/url.go
+++ b/internal/url/url.go
@@ -71,6 +71,15 @@ func normalizeURL(repoURL string) string {
 			path := parts[1]
 			repoURL = fmt.Sprintf("https://%s/%s", host, path)
 		}
+	} else if strings.HasPrefix(repoURL, "ssh://git@") {
+		// ssh://git@github.com:user/repo.git -> https://github.com/user/repo.git
+		repoURL = strings.TrimPrefix(repoURL, "ssh://")
+		parts := strings.SplitN(repoURL, ":", 2)
+		if len(parts) == 2 {
+			host := strings.TrimPrefix(parts[0], "git@")
+			path := parts[1]
+			repoURL = fmt.Sprintf("https://%s/%s", host, path)
+		}
 	}
 
 	// Ensure https:// prefix

--- a/internal/url/url_test.go
+++ b/internal/url/url_test.go
@@ -1,0 +1,48 @@
+package url
+
+import (
+	"testing"
+)
+
+func TestNormalizeURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "git@ format",
+			input:    "git@github.com:user/repo.git",
+			expected: "https://github.com/user/repo.git",
+		},
+		{
+			name:     "ssh://git@ format",
+			input:    "ssh://git@github.com:user/repo.git",
+			expected: "https://github.com/user/repo.git",
+		},
+		{
+			name:     "https format unchanged",
+			input:    "https://github.com/user/repo.git",
+			expected: "https://github.com/user/repo.git",
+		},
+		{
+			name:     "http format unchanged",
+			input:    "http://github.com/user/repo.git",
+			expected: "http://github.com/user/repo.git",
+		},
+		{
+			name:     "plain url gets https prefix",
+			input:    "github.com/user/repo.git",
+			expected: "https://github.com/user/repo.git",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizeURL(tt.input)
+			if result != tt.expected {
+				t.Errorf("normalizeURL(%s) = %s, want %s", tt.input, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Fixed URL normalization to properly handle `ssh://git@` prefixed Git URLs. Previously, these URLs were not being converted to HTTPS format, resulting in malformed worktree directory paths.

## Problem

When using repositories with `ssh://git@` URLs (e.g., `ssh://git@github.com/user/repo.git`), the URL normalization was failing, causing worktree paths to be created with the raw SSH URL format:

### Before (incorrect)
~/worktrees/ssh:/[git@github.com](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)/d-kuro/repo/branch

### Expected (correct)
~/worktrees/github.com/d-kuro/repo/branch

## Solution

Extended the `normalizeURL` function in `internal/url/url.go` to handle `ssh://git@` prefixed URLs by:

1. Adding detection for `ssh://git@` prefix
2. Converting these URLs to standard HTTPS format for consistent parsing
3. Maintaining existing functionality for `git@` (non-prefixed) SSH URLs

## Changes

- Updated `normalizeURL()` function to handle `ssh://git@` URLs
- Preserved existing `git@` handling as the primary case
- Added new `ssh://git@` handling as secondary case

## Testing

```bash
# Test with ssh:// prefixed URL
./gwq add -b test-branch
./gwq list
# Verify path format: ~/worktrees/github.com/user/repo/test-branch

