### PR TITLE
feat: Replace tabwriter with lipgloss/table for unified table styling

### DIFF
--- a/internal/claude/presenters/task_presenter.go
+++ b/internal/claude/presenters/task_presenter.go
@@ -7,9 +7,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/charmbracelet/lipgloss"
-	"github.com/charmbracelet/lipgloss/table"
 	"github.com/d-kuro/gwq/internal/claude"
+	"github.com/d-kuro/gwq/internal/table"
 )
 
 // TaskPresenter handles task display formatting
@@ -27,10 +26,8 @@ func (p *TaskPresenter) OutputTasksTable(tasks []*claude.Task, verbose bool) err
 		return nil
 	}
 
-	// Create table with lipgloss
-	t := table.New().
-		Border(lipgloss.NormalBorder()).
-		Headers("TASK", "WORKTREE", "STATUS", "PRIORITY", "DEPS", "DURATION")
+	// Create table with our new table package
+	t := table.New().Headers("TASK", "WORKTREE", "STATUS", "PRIORITY", "DEPS", "DURATION")
 
 	// Add rows to table
 	for _, task := range tasks {
@@ -67,8 +64,7 @@ func (p *TaskPresenter) OutputTasksTable(tasks []*claude.Task, verbose bool) err
 		}
 	}
 
-	fmt.Println(t)
-	return nil
+	return t.Println()
 }
 
 // OutputTaskDetails outputs detailed information about a task

--- a/internal/cmd/task_list.go
+++ b/internal/cmd/task_list.go
@@ -118,7 +118,7 @@ func outputTaskList(tasks []*claude.Task, presenter *presenters.TaskPresenter) e
 
 func outputTaskListCSV(tasks []*claude.Task) error {
 	// Create table with CSV-friendly data
-	t := table.New().Headers("TASK_ID", "WORKTREE", "STATUS", "PRIORITY", "DEPENDENCIES", "DURATION")
+	t := table.New().Headers("task_id", "worktree", "status", "priority", "dependencies", "duration")
 
 	// Add rows to table
 	for _, task := range tasks {

--- a/internal/cmd/task_list.go
+++ b/internal/cmd/task_list.go
@@ -2,11 +2,14 @@ package cmd
 
 import (
 	"fmt"
+	"strconv"
+	"time"
 
 	"github.com/d-kuro/gwq/internal/claude"
 	"github.com/d-kuro/gwq/internal/claude/presenters"
 	"github.com/d-kuro/gwq/internal/claude/services"
 	"github.com/d-kuro/gwq/internal/config"
+	"github.com/d-kuro/gwq/internal/table"
 	"github.com/spf13/cobra"
 )
 
@@ -114,8 +117,49 @@ func outputTaskList(tasks []*claude.Task, presenter *presenters.TaskPresenter) e
 }
 
 func outputTaskListCSV(tasks []*claude.Task) error {
-	// TODO: Implement CSV output using presenter
-	return fmt.Errorf("CSV output not yet implemented")
+	// Create table with CSV-friendly data
+	t := table.New().Headers("TASK_ID", "WORKTREE", "STATUS", "PRIORITY", "DEPENDENCIES", "DURATION")
+
+	// Add rows to table
+	for _, task := range tasks {
+		status := string(task.Status)
+
+		worktree := task.Worktree
+
+		deps := strconv.Itoa(len(task.DependsOn))
+		if len(task.DependsOn) == 0 {
+			deps = "0"
+		}
+
+		duration := ""
+		if task.Result != nil {
+			duration = formatDurationForCSV(task.Result.Duration)
+		} else if task.StartedAt != nil {
+			duration = formatDurationForCSV(time.Since(*task.StartedAt))
+		}
+
+		t.Row(
+			task.ID,
+			worktree,
+			status,
+			strconv.Itoa(int(task.Priority)),
+			deps,
+			duration,
+		)
+	}
+
+	return t.WriteCSV()
+}
+
+// formatDurationForCSV formats a duration for CSV output (no special characters)
+func formatDurationForCSV(d time.Duration) string {
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	}
+	return fmt.Sprintf("%dh%dm", int(d.Hours()), int(d.Minutes())%60)
 }
 
 func watchTaskList() error {

--- a/internal/cmd/tmux_list.go
+++ b/internal/cmd/tmux_list.go
@@ -152,7 +152,7 @@ func outputSessionsJSON(sessions []*tmux.Session) error {
 }
 
 func outputSessionsCSV(sessions []*tmux.Session) error {
-	t := table.New().Headers("Context", "Identifier", "Duration", "Command", "WorkingDir", "SessionName")
+	t := table.New().Headers("context", "identifier", "duration", "command", "working_dir", "session_name")
 
 	// Write data
 	for _, session := range sessions {

--- a/internal/table/table.go
+++ b/internal/table/table.go
@@ -1,0 +1,249 @@
+package table
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/lipgloss/table"
+)
+
+// Builder provides a convenient interface for creating styled tables using lipgloss/table
+type Builder struct {
+	headers []string
+	rows    [][]string
+	style   Style
+	output  io.Writer
+}
+
+// Style defines the visual styling options for tables
+type Style struct {
+	Border lipgloss.Border
+	// HeaderStyle applies styling to header row
+	HeaderStyle lipgloss.Style
+	// CellStyle applies styling to data cells
+	CellStyle lipgloss.Style
+	// Width sets the table width (0 for auto-width)
+	Width int
+	// MarginLeft sets left margin (default: 1)
+	MarginLeft int
+	// MarginRight sets right margin (default: 1)
+	MarginRight int
+	// PaddingLeft sets left padding inside cells (default: 1)
+	PaddingLeft int
+	// PaddingRight sets right padding inside cells (default: 1)
+	PaddingRight int
+}
+
+// DefaultStyle returns a clean default style for tables
+func DefaultStyle() Style {
+	return Style{
+		Border: lipgloss.NormalBorder(),
+		HeaderStyle: lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("15")).
+			Background(lipgloss.Color("8")),
+		CellStyle:    lipgloss.NewStyle(),
+		Width:        0,
+		MarginLeft:   1,
+		MarginRight:  1,
+		PaddingLeft:  1,
+		PaddingRight: 1,
+	}
+}
+
+// MinimalStyle returns a minimal border style for simple tables
+func MinimalStyle() Style {
+	return Style{
+		Border:       lipgloss.RoundedBorder(),
+		HeaderStyle:  lipgloss.NewStyle().Bold(true),
+		CellStyle:    lipgloss.NewStyle(),
+		Width:        0,
+		MarginLeft:   1,
+		MarginRight:  1,
+		PaddingLeft:  1,
+		PaddingRight: 1,
+	}
+}
+
+// NoBorderStyle returns a borderless style for compact output
+func NoBorderStyle() Style {
+	return Style{
+		Border:       lipgloss.Border{},
+		HeaderStyle:  lipgloss.NewStyle().Bold(true).Underline(true),
+		CellStyle:    lipgloss.NewStyle(),
+		Width:        0,
+		MarginLeft:   0,
+		MarginRight:  0,
+		PaddingLeft:  0,
+		PaddingRight: 0,
+	}
+}
+
+// New creates a new table builder with default styling
+func New() *Builder {
+	return &Builder{
+		style:  DefaultStyle(),
+		output: os.Stdout,
+	}
+}
+
+// NewWithStyle creates a new table builder with custom styling
+func NewWithStyle(style Style) *Builder {
+	return &Builder{
+		style:  style,
+		output: os.Stdout,
+	}
+}
+
+// SetOutput sets the output writer for the table
+func (b *Builder) SetOutput(w io.Writer) *Builder {
+	b.output = w
+	return b
+}
+
+// Headers sets the table headers
+func (b *Builder) Headers(headers ...string) *Builder {
+	b.headers = make([]string, len(headers))
+	copy(b.headers, headers)
+	return b
+}
+
+// Row adds a data row to the table
+func (b *Builder) Row(columns ...string) *Builder {
+	row := make([]string, len(columns))
+	copy(row, columns)
+	b.rows = append(b.rows, row)
+	return b
+}
+
+// Rows adds multiple data rows to the table
+func (b *Builder) Rows(rows [][]string) *Builder {
+	for _, row := range rows {
+		b.Row(row...)
+	}
+	return b
+}
+
+// Build creates and returns the formatted table as a string
+func (b *Builder) Build() string {
+	t := table.New().
+		Border(b.style.Border).
+		StyleFunc(func(row, col int) lipgloss.Style {
+			// Apply padding to all cells for better readability
+			return lipgloss.NewStyle().
+				PaddingLeft(b.style.PaddingLeft).
+				PaddingRight(b.style.PaddingRight)
+		})
+
+	// Set width if specified
+	if b.style.Width > 0 {
+		t.Width(b.style.Width)
+	}
+
+	// Add headers if provided
+	if len(b.headers) > 0 {
+		t.Headers(b.headers...)
+	}
+
+	// Add all rows
+	for _, row := range b.rows {
+		t.Row(row...)
+	}
+
+	// Render the table and apply margin styling
+	tableOutput := t.Render()
+
+	// Apply margins based on style configuration
+	styledTable := lipgloss.NewStyle().
+		MarginLeft(b.style.MarginLeft).
+		MarginRight(b.style.MarginRight).
+		Render(tableOutput)
+
+	return styledTable
+}
+
+// Print writes the table to the configured output writer
+func (b *Builder) Print() error {
+	_, err := fmt.Fprint(b.output, b.Build())
+	return err
+}
+
+// Println writes the table followed by a newline to the configured output writer
+func (b *Builder) Println() error {
+	_, err := fmt.Fprintln(b.output, b.Build())
+	return err
+}
+
+// WriteCSV writes the table data in CSV format to the output writer
+func (b *Builder) WriteCSV() error {
+	// Write headers if present
+	if len(b.headers) > 0 {
+		_, err := fmt.Fprintln(b.output, strings.Join(b.headers, ","))
+		if err != nil {
+			return err
+		}
+	}
+
+	// Write data rows
+	for _, row := range b.rows {
+		// Escape CSV fields that contain commas or quotes
+		escapedRow := make([]string, len(row))
+		for i, field := range row {
+			if strings.Contains(field, ",") || strings.Contains(field, "\"") || strings.Contains(field, "\n") {
+				escapedRow[i] = "\"" + strings.ReplaceAll(field, "\"", "\"\"") + "\""
+			} else {
+				escapedRow[i] = field
+			}
+		}
+		_, err := fmt.Fprintln(b.output, strings.Join(escapedRow, ","))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// SetMargins sets the left and right margins for the table
+func (b *Builder) SetMargins(left, right int) *Builder {
+	b.style.MarginLeft = left
+	b.style.MarginRight = right
+	return b
+}
+
+// SetPadding sets the left and right padding inside cells
+func (b *Builder) SetPadding(left, right int) *Builder {
+	b.style.PaddingLeft = left
+	b.style.PaddingRight = right
+	return b
+}
+
+// Clear resets the table data but keeps the styling
+func (b *Builder) Clear() *Builder {
+	b.headers = nil
+	b.rows = nil
+	return b
+}
+
+// RowCount returns the number of data rows in the table
+func (b *Builder) RowCount() int {
+	return len(b.rows)
+}
+
+// HasHeaders returns true if headers are set
+func (b *Builder) HasHeaders() bool {
+	return len(b.headers) > 0
+}
+
+// Simple is a convenience function to quickly create and print a table
+func Simple(headers []string, rows [][]string) error {
+	return New().Headers(headers...).Rows(rows).Println()
+}
+
+// SimpleWithStyle is a convenience function to quickly create and print a styled table
+func SimpleWithStyle(style Style, headers []string, rows [][]string) error {
+	return NewWithStyle(style).Headers(headers...).Rows(rows).Println()
+}


### PR DESCRIPTION
## Summary
Replace all `tabwriter.NewWriter` usage with a new unified table package based on `github.com/charmbracelet/lipgloss/table` to provide consistent, beautiful table formatting across all gwq commands.

## Changes Made

### 🆕 New Package: `internal/table`
- **Builder pattern API** for flexible table creation
- **Multiple styling options**: Default, Minimal, and NoBorder styles
- **Configurable margins and padding** for better readability
- **CSV export functionality** with proper field escaping
- **Consistent API** across all table outputs

### 🔄 Updated Files
- **`internal/claude/presenters/task_presenter.go`**: Updated task table output
- **`internal/cmd/task_list.go`**: Implemented CSV functionality (was previously TODO)
- **`internal/cmd/status_output.go`**: Replaced tabwriter with new table package
- **`internal/cmd/tmux_list.go`**: Updated tmux session tables
- **`internal/ui/ui.go`**: Updated worktree and branch tables + improved error handling

### ✨ Key Improvements
- **Consistent styling** across all table outputs
- **Better readability** with configurable cell padding: `| name | value |` style
- **Enhanced CSV support** with proper escaping
- **Cleaner codebase** with unified table logic
- **Better maintainability** through centralized styling

## Test plan
- [x] All existing tests pass
- [x] Linting passes with no issues
- [x] Manual testing of table outputs:
  - [x] `gwq task list` - displays with proper padding and margins
  - [x] `gwq task list --csv` - now works (was previously unimplemented)
  - [x] `gwq status` - consistent table styling
  - [x] `gwq tmux list` - improved formatting
  - [x] `gwq list` - unified worktree display

## Before/After

### Before (cramped)
```
┌──────────┬──────────┬─────────┬────────┬────┬────────┐
│TASK      │WORKTREE  │STATUS   │PRIORITY│DEPS│DURATION│
├──────────┼──────────┼─────────┼────────┼────┼────────┤
│✓ 1fe3d8fb│test/test3│completed│75      │1   │14s     │
└──────────┴──────────┴─────────┴────────┴────┴────────┘
```

### After (readable)
```
 ┌────────────┬────────────┬───────────┬──────────┬──────┬──────────┐
 │ TASK       │ WORKTREE   │ STATUS    │ PRIORITY │ DEPS │ DURATION │
 ├────────────┼────────────┼───────────┼──────────┼──────┼──────────┤
 │ ✓ 1fe3d8fb │ test/test3 │ completed │ 75       │ 1    │ 14s      │
 └────────────┴────────────┴───────────┴──────────┴──────┴──────────┘
```

🤖 Generated with [Claude Code](https://claude.ai/code)