### PR TITLE
feat: Add constants for worktree type display names

### DIFF
--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -47,9 +47,9 @@ func (p *Printer) PrintWorktrees(worktrees []models.Worktree, verbose bool) {
 	if verbose {
 		t = table.New().Headers("BRANCH", "PATH", "COMMIT", "CREATED", "TYPE")
 		for _, wt := range worktrees {
-			wtType := "additional"
+			wtType := models.WorktreeTypeWorktree
 			if wt.IsMain {
-				wtType = "main"
+				wtType = models.WorktreeTypeMain
 			}
 			path := wt.Path
 			if p.useTildeHome {

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -192,3 +192,11 @@ type ClaudeHeadlessFormattingConfig struct {
 	ShowTimingInfo    bool `mapstructure:"show_timing_info"`    // Show timing information
 	MaxContentLength  int  `mapstructure:"max_content_length"`  // Maximum content length for display
 }
+
+// Worktree type constants for display purposes.
+const (
+	// WorktreeTypeMain represents the main worktree (repository root).
+	WorktreeTypeMain = "main"
+	// WorktreeTypeWorktree represents an additional worktree.
+	WorktreeTypeWorktree = "worktree"
+)


### PR DESCRIPTION
## Summary
- Add `WorktreeTypeMain` and `WorktreeTypeWorktree` constants to models package
- Improve code maintainability by using constants instead of hardcoded strings
- Change "additional" to "worktree" for better clarity while keeping "main" for primary worktrees

## Test plan
- [x] Run `make fmt` - formatting passed
- [x] Run `make lint` - no linting issues
- [x] Run `make test` - all tests pass
- [x] Verify `gwq list -v` displays correct type names

🤖 Generated with [Claude Code](https://claude.ai/code)