### PR TITLE
fix: Add missing bullet indicator for main branch in verbose list mode

### DIFF
--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -51,12 +51,21 @@ func (p *Printer) PrintWorktrees(worktrees []models.Worktree, verbose bool) {
 			if wt.IsMain {
 				wtType = models.WorktreeTypeMain
 			}
+
+			// Apply marker with consistent spacing
+			var branchWithMarker string
+			if wt.IsMain && p.useIcons {
+				branchWithMarker = "● " + wt.Branch
+			} else {
+				branchWithMarker = "  " + wt.Branch // Two spaces to match "● " width
+			}
+
 			path := wt.Path
 			if p.useTildeHome {
 				path = utils.TildePath(path)
 			}
 			t.Row(
-				wt.Branch,
+				branchWithMarker,
 				path,
 				p.truncateHash(wt.CommitHash),
 				p.formatTime(wt.CreatedAt),


### PR DESCRIPTION
## Summary
- Fixed missing bullet point (●) indicator for main branch when using `gwq list -v`
- Added the same marker logic from normal mode to verbose mode for consistency

## Problem
The bullet point indicator that shows which worktree is the main branch was only appearing in normal list mode (`gwq list`) but was missing in verbose mode (`gwq list -v`).

## Solution  
Added the bullet point marker logic to the verbose mode table creation in `internal/ui/ui.go`, ensuring both display modes show the visual indicator consistently.

## Test plan
- [x] Verified `gwq list` still shows bullet point for main branch
- [x] Verified `gwq list -v` now shows bullet point for main branch  
- [x] All tests pass
- [x] Code passes linting and formatting checks

🤖 Generated with [Claude Code](https://claude.ai/code)