### PR TITLE
fix: resolve exec command issues with --stay and --help options

### DIFF
--- a/internal/cmd/exec.go
+++ b/internal/cmd/exec.go
@@ -312,7 +312,7 @@ func executeInWorktree(worktreePath string, commandArgs []string, stay bool) err
 		shellCmd.Stderr = os.Stderr
 
 		// Run the shell regardless of the original command's exit status
-		shellCmd.Run()
+		_ = shellCmd.Run()
 	}
 
 	return err

--- a/internal/cmd/exec.go
+++ b/internal/cmd/exec.go
@@ -293,7 +293,7 @@ func executeInWorktree(worktreePath string, commandArgs []string, stay bool) err
 	cmd.Stderr = os.Stderr
 
 	err := cmd.Run()
-	
+
 	if stay {
 		// Launch a new shell in the worktree directory after command execution
 		shell := os.Getenv("SHELL")

--- a/internal/cmd/exec.go
+++ b/internal/cmd/exec.go
@@ -131,6 +131,11 @@ func runExec(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Check if parsedArgs is nil (e.g., when --help is used)
+	if parsedArgs == nil {
+		return nil
+	}
+
 	// Set global variables for backward compatibility
 	execGlobal = parsedArgs.global
 	execStay = parsedArgs.stay
@@ -273,26 +278,6 @@ func getGlobalWorktreePathForExec(cfg *models.Config, pattern string) (string, e
 }
 
 func executeInWorktree(worktreePath string, commandArgs []string, stay bool) error {
-	if stay {
-		// Launch a new shell in the worktree directory
-		shell := os.Getenv("SHELL")
-		if shell == "" {
-			shell = "/bin/sh"
-		}
-
-		fmt.Printf("Launching shell in: %s\n", worktreePath)
-		fmt.Println("Type 'exit' to return to the original directory")
-
-		cmd := exec.Command(shell)
-		cmd.Dir = worktreePath
-		cmd.Env = os.Environ()
-		cmd.Stdin = os.Stdin
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-
-		return cmd.Run()
-	}
-
 	// Execute the command in the worktree directory
 	var cmd *exec.Cmd
 	if len(commandArgs) == 1 {
@@ -307,5 +292,28 @@ func executeInWorktree(worktreePath string, commandArgs []string, stay bool) err
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	return cmd.Run()
+	err := cmd.Run()
+	
+	if stay {
+		// Launch a new shell in the worktree directory after command execution
+		shell := os.Getenv("SHELL")
+		if shell == "" {
+			shell = "/bin/sh"
+		}
+
+		fmt.Printf("Launching shell in: %s\n", worktreePath)
+		fmt.Println("Type 'exit' to return to the original directory")
+
+		shellCmd := exec.Command(shell)
+		shellCmd.Dir = worktreePath
+		shellCmd.Env = os.Environ()
+		shellCmd.Stdin = os.Stdin
+		shellCmd.Stdout = os.Stdout
+		shellCmd.Stderr = os.Stderr
+
+		// Run the shell regardless of the original command's exit status
+		shellCmd.Run()
+	}
+
+	return err
 }


### PR DESCRIPTION
## Summary
- Fixes issue where `gwq exec --stay` commands fail to execute the specified command
- Resolves panic when using `gwq exec --help` due to nil pointer dereference
- Ensures proper command execution flow in both normal and stay modes
- Maintains backward compatibility with existing gwq exec functionality

## Key Changes
1. Fixed `executeInWorktree` function to execute command first, then launch shell in stay mode
2. Added nil check in `runExec` function to prevent panic when `--help` is used
3. Ensures both command execution and shell launching work properly in `--stay` mode
4. Maintains original command exit status while still launching shell in stay mode

## Problem Solved
- Commands executed via `gwq exec --stay` previously skipped command execution
- `gwq exec --help` caused panic due to nil pointer access
- Stay mode launched shell without running the specified command first

## Example Fix
Before:
```bash
❯ gwq exec feature/branch --stay -- ls
# Shell launched immediately without executing 'ls'

❯ gwq exec --help
# Panic: runtime error: invalid memory address or nil pointer dereference
```

After:
```bash
❯ gwq exec feature/branch --stay -- ls
# First executes 'ls' command, then launches shell in worktree directory

❯ gwq exec --help
# Displays help information properly
```

## Files Modified
- `internal/cmd/exec.go` - Fixed command execution flow and nil pointer handling

## Quality Verification
- No breaking changes to existing functionality
- Maintains backward compatibility
- Both stay and normal modes execute commands properly
- Help command works without panic

## Outcome
- Resolves command execution failures in stay mode
- Eliminates panic when requesting help
- Enables seamless development workflow with --stay option
- Maintains all existing gwq exec functionality