### PR TITLE
fix: support git URLs using SSH config aliases

### DIFF
--- a/internal/url/url.go
+++ b/internal/url/url.go
@@ -78,6 +78,11 @@ func normalizeURL(repoURL string) string {
 			host = strings.TrimPrefix(host, "git@")
 			repoURL = fmt.Sprintf("https://%s/%s", host, path)
 		}
+	} else if isSCPLikeURL(repoURL) {
+		// SCP-like format without git@ prefix (e.g., SSH config alias)
+		// workgit:myorg/myrepo.git -> https://workgit/myorg/myrepo.git
+		host, path, _ := strings.Cut(repoURL, ":")
+		repoURL = fmt.Sprintf("https://%s/%s", host, path)
 	}
 
 	// Ensure https:// prefix
@@ -86,6 +91,44 @@ func normalizeURL(repoURL string) string {
 	}
 
 	return repoURL
+}
+
+// isSCPLikeURL checks if a URL string uses SCP-like syntax (host:path)
+// without a git@ prefix. This handles SSH config aliases like "workgit:org/repo.git".
+//
+// Limitation: "host:123/path" where the first path segment is all digits is treated
+// as a port number (host:port/path), not SCP-like. This means SSH aliases with
+// numeric-only first path segments are not detected. This is an acceptable tradeoff
+// since such paths are extremely rare in practice.
+func isSCPLikeURL(rawURL string) bool {
+	if strings.Contains(rawURL, "://") {
+		return false
+	}
+
+	if strings.HasPrefix(rawURL, "git@") {
+		return false
+	}
+
+	// Exclude bracketed IPv6 addresses (e.g., "[::1]:8080/user/repo")
+	if strings.HasPrefix(rawURL, "[") {
+		return false
+	}
+
+	_, after, found := strings.Cut(rawURL, ":")
+	if !found || after == "" {
+		return false
+	}
+
+	// Check if the segment before the first '/' is all digits (a port number).
+	portOrPath, _, _ := strings.Cut(after, "/")
+
+	for _, c := range portOrPath {
+		if c < '0' || c > '9' {
+			return true
+		}
+	}
+
+	return false
 }
 
 // sanitizeBranchName converts branch names to filesystem-safe names.

--- a/internal/url/url_test.go
+++ b/internal/url/url_test.go
@@ -63,6 +63,41 @@ func TestParseRepositoryURL(t *testing.T) {
 			wantRepo:  "repo",
 		},
 		{
+			name:      "SSH config alias",
+			input:     "workgit:myorg/myrepo.git",
+			wantHost:  "workgit",
+			wantOwner: "myorg",
+			wantRepo:  "myrepo",
+		},
+		{
+			name:      "SSH config alias without .git",
+			input:     "myalias:owner/repo",
+			wantHost:  "myalias",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+		},
+		{
+			name:      "SSH config alias with nested path",
+			input:     "myhost:org/team/repo.git",
+			wantHost:  "myhost",
+			wantOwner: "org",
+			wantRepo:  "repo",
+		},
+		{
+			name:      "git@ with SSH config alias",
+			input:     "git@workgit:org/repo.git",
+			wantHost:  "workgit",
+			wantOwner: "org",
+			wantRepo:  "repo",
+		},
+		{
+			name:      "URL with port number",
+			input:     "localhost:8080/user/repo",
+			wantHost:  "localhost:8080",
+			wantOwner: "user",
+			wantRepo:  "repo",
+		},
+		{
 			name:    "single path component is invalid",
 			input:   "https://github.com/user",
 			wantErr: true,
@@ -99,6 +134,74 @@ func TestParseRepositoryURL(t *testing.T) {
 	}
 }
 
+func TestIsSCPLikeURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{
+			name:     "basic SSH config alias",
+			input:    "workgit:myorg/myrepo.git",
+			expected: true,
+		},
+		{
+			name:     "alias without .git",
+			input:    "myalias:owner/repo",
+			expected: true,
+		},
+		{
+			name:     "port number URL",
+			input:    "localhost:8080/user/repo",
+			expected: false,
+		},
+		{
+			name:     "port only without path",
+			input:    "localhost:8080",
+			expected: false,
+		},
+		{
+			name:     "URL with scheme",
+			input:    "https://github.com/user/repo",
+			expected: false,
+		},
+		{
+			name:     "git@ prefix",
+			input:    "git@github.com:user/repo.git",
+			expected: false,
+		},
+		{
+			name:     "empty path after colon",
+			input:    "host:",
+			expected: false,
+		},
+		{
+			name:     "no colon",
+			input:    "github.com/user/repo",
+			expected: false,
+		},
+		{
+			name:     "colon followed by slash",
+			input:    "host:/user/repo",
+			expected: false,
+		},
+		{
+			name:     "bracketed IPv6 address",
+			input:    "[::1]:8080/user/repo",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isSCPLikeURL(tt.input)
+			if result != tt.expected {
+				t.Errorf("isSCPLikeURL(%q) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
 func TestNormalizeURL(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -129,6 +232,31 @@ func TestNormalizeURL(t *testing.T) {
 			name:     "plain url gets https prefix",
 			input:    "github.com/user/repo.git",
 			expected: "https://github.com/user/repo.git",
+		},
+		{
+			name:     "SSH config alias SCP format",
+			input:    "workgit:myorg/myrepo.git",
+			expected: "https://workgit/myorg/myrepo.git",
+		},
+		{
+			name:     "SSH config alias without .git",
+			input:    "myalias:owner/repo",
+			expected: "https://myalias/owner/repo",
+		},
+		{
+			name:     "SSH config alias with nested path",
+			input:    "myhost:org/team/repo.git",
+			expected: "https://myhost/org/team/repo.git",
+		},
+		{
+			name:     "URL with port number is not SCP",
+			input:    "localhost:8080/user/repo",
+			expected: "https://localhost:8080/user/repo",
+		},
+		{
+			name:     "git@ with SSH config alias",
+			input:    "git@workgit:org/repo.git",
+			expected: "https://workgit/org/repo.git",
 		},
 	}
 


### PR DESCRIPTION
## Summary

- Fix `gwq add` failing when the git remote uses an SSH config alias without `git@` prefix (e.g., `workgit:myorg/myrepo.git`)
- Add `isSCPLikeURL()` helper to detect SCP-like syntax and convert `host:path` to `https://host/path` for URL parsing
- Distinguish SCP-like aliases from `host:port` URLs by checking if the segment after `:` is numeric

Closes #88

## Test plan

- [x] `TestIsSCPLikeURL` — 10 cases covering aliases, ports, schemes, IPv6, edge cases
- [x] `TestNormalizeURL` — 5 new cases for alias SCP, port URLs, `git@` alias regression
- [x] `TestParseRepositoryURL` — 5 new cases for end-to-end alias parsing
- [x] `make test` passes
- [x] `make lint` passes