### PR TITLE
fix: include main worktrees, exclude submodules, preserve glob patterns

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/d-kuro/gwq/internal/utils"
 	"github.com/d-kuro/gwq/pkg/models"
@@ -183,7 +184,13 @@ func expandConfigPaths(cfg *models.Config) error {
 	cfg.Worktree.BaseDir = expandedPath
 
 	for i := range cfg.RepositorySettings {
-		expandedPath, err = utils.ExpandPath(cfg.RepositorySettings[i].Repository)
+		repo := cfg.RepositorySettings[i].Repository
+		// Skip path expansion for glob patterns — ExpandPath would prepend
+		// the CWD to relative globs like "**/owner/repo", breaking matching.
+		if strings.ContainsAny(repo, "*?[") {
+			continue
+		}
+		expandedPath, err = utils.ExpandPath(repo)
 		if err != nil {
 			return fmt.Errorf("failed to expand repository setting path: %w", err)
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -69,6 +69,40 @@ setup_commands = ["touch bar"]
 	}
 }
 
+func TestRepositorySettingsGlobPatternPreserved(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(func() { viper.Reset() })
+	viper.SetConfigType("toml")
+	configTOML := `
+[[repository_settings]]
+repository = "**/cerebras/monolith"
+setup_commands = ["make_vscode"]
+
+[[repository_settings]]
+repository = "/tmp/exact-path"
+setup_commands = ["echo hi"]
+`
+	if err := viper.ReadConfig(strings.NewReader(configTOML)); err != nil {
+		t.Fatalf("Failed to read config: %v", err)
+	}
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Failed to load config: %v", err)
+	}
+
+	// Glob pattern should be preserved as-is (not expanded to absolute path)
+	if cfg.RepositorySettings[0].Repository != "**/cerebras/monolith" {
+		t.Errorf("Glob pattern was mangled: got %q, want %q",
+			cfg.RepositorySettings[0].Repository, "**/cerebras/monolith")
+	}
+
+	// Exact path should still be expanded normally
+	if cfg.RepositorySettings[1].Repository != "/tmp/exact-path" {
+		t.Errorf("Exact path was changed: got %q, want %q",
+			cfg.RepositorySettings[1].Repository, "/tmp/exact-path")
+	}
+}
+
 func TestLoadIgnoresLegacyClaudeSettings(t *testing.T) {
 	viper.Reset()
 	t.Cleanup(func() {

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -48,35 +48,53 @@ func DiscoverGlobalWorktrees(baseDir string) ([]*GlobalWorktreeEntry, error) {
 			return nil // Skip errors and continue walking
 		}
 
-		// Skip if not a directory
 		if !info.IsDir() {
 			return nil
 		}
 
-		// Check if this directory contains a .git file (worktree marker)
-		gitFile := filepath.Join(path, ".git")
-		if _, err := os.Stat(gitFile); err != nil {
-			return nil // Not a git worktree, continue
+		// Skip .git directories themselves
+		if info.Name() == ".git" {
+			return filepath.SkipDir
 		}
 
-		// Try to determine if this is a worktree by reading .git file
-		gitContent, err := os.ReadFile(gitFile)
+		gitPath := filepath.Join(path, ".git")
+		gitInfo, err := os.Stat(gitPath)
+		if err != nil {
+			return nil // No .git entry, continue
+		}
+
+		if gitInfo.IsDir() {
+			// Main worktree (.git is a directory)
+			entry, err := extractWorktreeInfo(path)
+			if err != nil {
+				return filepath.SkipDir // Skip broken repos but don't walk into them
+			}
+			entry.IsMain = true
+			entries = append(entries, entry)
+			return filepath.SkipDir // Don't descend into the repo
+		}
+
+		// Linked worktree (.git is a file)
+		gitContent, err := os.ReadFile(gitPath)
 		if err != nil {
 			return nil
 		}
 
 		gitContentStr := strings.TrimSpace(string(gitContent))
 		if !strings.HasPrefix(gitContentStr, "gitdir: ") {
-			return nil // Not a worktree, it's a main repository
-		}
-
-		// This is a worktree, extract information
-		entry, err := extractWorktreeInfo(path)
-		if err != nil {
-			// Log error but continue discovery
 			return nil
 		}
 
+		// Skip submodules — their gitdir points to .git/modules/...
+		gitDir := strings.TrimPrefix(gitContentStr, "gitdir: ")
+		if isSubmoduleGitDir(gitDir) {
+			return nil
+		}
+
+		entry, err := extractWorktreeInfo(path)
+		if err != nil {
+			return nil
+		}
 		entries = append(entries, entry)
 		return nil
 	})
@@ -159,6 +177,14 @@ func getCurrentCommitHash(worktreePath string) (string, error) {
 	}
 
 	return strings.TrimSpace(output), nil
+}
+
+// isSubmoduleGitDir checks whether a gitdir path points to a submodule
+// rather than a worktree. Submodule gitdirs contain ".git/modules/" while
+// worktree gitdirs contain ".git/worktrees/".
+func isSubmoduleGitDir(gitDir string) bool {
+	return strings.Contains(gitDir, ".git/modules/") ||
+		strings.Contains(gitDir, ".git\\modules\\")
 }
 
 // ConvertToWorktreeModels converts GlobalWorktreeEntry to models.Worktree.

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -135,16 +135,12 @@ func extractWorktreeInfo(worktreePath string) (*GlobalWorktreeEntry, error) {
 		return nil, fmt.Errorf("failed to get commit hash: %w", err)
 	}
 
-	// Check if this is the main worktree (unlikely since we filtered for worktrees)
-	isMain := false
-
 	return &GlobalWorktreeEntry{
 		RepositoryURL:  repoURL,
 		RepositoryInfo: repoInfo,
 		Branch:         branch,
 		Path:           worktreePath,
 		CommitHash:     commitHash,
-		IsMain:         isMain,
 	}, nil
 }
 

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -176,11 +176,14 @@ func getCurrentCommitHash(worktreePath string) (string, error) {
 }
 
 // isSubmoduleGitDir checks whether a gitdir path points to a submodule
-// rather than a worktree. Submodule gitdirs contain ".git/modules/" while
-// worktree gitdirs contain ".git/worktrees/".
+// rather than a linked worktree. Submodule gitdirs always contain a
+// "/modules/" segment — either under .git/modules/ (submodules in the main
+// worktree) or under .git/worktrees/<name>/modules/ (submodules in a linked
+// worktree). Linked worktree gitdirs point to .git/worktrees/<name> with no
+// trailing /modules/ path.
 func isSubmoduleGitDir(gitDir string) bool {
-	return strings.Contains(gitDir, ".git/modules/") ||
-		strings.Contains(gitDir, ".git\\modules\\")
+	normalized := filepath.ToSlash(gitDir)
+	return strings.Contains(normalized, "/modules/")
 }
 
 // ConvertToWorktreeModels converts GlobalWorktreeEntry to models.Worktree.

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -148,28 +148,159 @@ func TestDiscoverGlobalWorktrees_NoWorktrees(t *testing.T) {
 	}
 }
 
-func TestDiscoverGlobalWorktrees_SingleWorktree(t *testing.T) {
-	// Skip this test for now as it requires complex git setup
-	// TODO: Implement with mocked git operations
-	t.Skip("Skipping complex git test - needs mock implementation")
+func TestDiscoverGlobalWorktrees_IncludesMainWorktree(t *testing.T) {
+	baseDir := t.TempDir()
+
+	// Create a real git repo inside the base directory
+	repoDir := filepath.Join(baseDir, "github.com", "user", "repo", "main")
+	if err := os.MkdirAll(repoDir, 0755); err != nil {
+		t.Fatalf("Failed to create repo directory: %v", err)
+	}
+
+	repo := &TestRepository{Path: repoDir}
+	if err := repo.run("init", "-b", "main"); err != nil {
+		t.Fatalf("Failed to init: %v", err)
+	}
+	if err := repo.run("config", "user.name", "Test"); err != nil {
+		t.Fatalf("Failed to set user.name: %v", err)
+	}
+	if err := repo.run("config", "user.email", "test@test.com"); err != nil {
+		t.Fatalf("Failed to set user.email: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("# test\n"), 0644); err != nil {
+		t.Fatalf("Failed to write file: %v", err)
+	}
+	if err := repo.run("add", "."); err != nil {
+		t.Fatalf("Failed to add: %v", err)
+	}
+	if err := repo.run("commit", "-m", "init"); err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+	repo.AddRemote(t, "origin", "https://github.com/user/repo.git")
+
+	entries, err := DiscoverGlobalWorktrees(baseDir)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if len(entries) != 1 {
+		t.Fatalf("Expected 1 entry, got %d", len(entries))
+	}
+
+	if !entries[0].IsMain {
+		t.Error("Expected entry to be marked as main worktree")
+	}
+	if entries[0].Branch != "main" {
+		t.Errorf("Expected branch 'main', got '%s'", entries[0].Branch)
+	}
 }
 
-func TestDiscoverGlobalWorktrees_MultipleWorktrees(t *testing.T) {
-	// Skip this test for now as it requires complex git setup
-	// TODO: Implement with mocked git operations
-	t.Skip("Skipping complex git test - needs mock implementation")
+func TestDiscoverGlobalWorktrees_MainAndLinkedWorktrees(t *testing.T) {
+	baseDir := t.TempDir()
+
+	// Create main repo
+	repoDir := filepath.Join(baseDir, "github.com", "user", "repo", "main")
+	if err := os.MkdirAll(repoDir, 0755); err != nil {
+		t.Fatalf("Failed to create repo directory: %v", err)
+	}
+
+	repo := &TestRepository{Path: repoDir}
+	if err := repo.run("init", "-b", "main"); err != nil {
+		t.Fatalf("Failed to init: %v", err)
+	}
+	if err := repo.run("config", "user.name", "Test"); err != nil {
+		t.Fatalf("Failed to set user.name: %v", err)
+	}
+	if err := repo.run("config", "user.email", "test@test.com"); err != nil {
+		t.Fatalf("Failed to set user.email: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("# test\n"), 0644); err != nil {
+		t.Fatalf("Failed to write file: %v", err)
+	}
+	if err := repo.run("add", "."); err != nil {
+		t.Fatalf("Failed to add: %v", err)
+	}
+	if err := repo.run("commit", "-m", "init"); err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+	repo.AddRemote(t, "origin", "https://github.com/user/repo.git")
+
+	// Create a branch and linked worktree
+	repo.CreateBranch(t, "feature")
+	if err := repo.run("checkout", "main"); err != nil {
+		t.Fatalf("Failed to checkout main: %v", err)
+	}
+	worktreeDir := filepath.Join(baseDir, "github.com", "user", "repo", "feature")
+	repo.CreateWorktree(t, worktreeDir, "feature")
+
+	entries, err := DiscoverGlobalWorktrees(baseDir)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if len(entries) != 2 {
+		t.Fatalf("Expected 2 entries, got %d", len(entries))
+	}
+
+	var mainCount, linkedCount int
+	for _, e := range entries {
+		if e.IsMain {
+			mainCount++
+		} else {
+			linkedCount++
+		}
+	}
+	if mainCount != 1 {
+		t.Errorf("Expected 1 main worktree, got %d", mainCount)
+	}
+	if linkedCount != 1 {
+		t.Errorf("Expected 1 linked worktree, got %d", linkedCount)
+	}
 }
 
-func TestDiscoverGlobalWorktrees_SkipsMainRepositories(t *testing.T) {
-	// Skip this test for now as it requires complex git setup
-	// TODO: Implement with mocked git operations
-	t.Skip("Skipping complex git test - needs mock implementation")
-}
+func TestDiscoverGlobalWorktrees_SkipsSubmodulesInsideMainRepo(t *testing.T) {
+	baseDir := t.TempDir()
 
-func TestExtractWorktreeInfo_ValidWorktree(t *testing.T) {
-	// Skip this test for now as it requires complex git setup
-	// TODO: Implement with mocked git operations
-	t.Skip("Skipping complex git test - needs mock implementation")
+	// Create a main repo with a fake submodule inside it
+	repoDir := filepath.Join(baseDir, "repo")
+	if err := os.MkdirAll(repoDir, 0755); err != nil {
+		t.Fatalf("Failed to create repo directory: %v", err)
+	}
+
+	repo := &TestRepository{Path: repoDir}
+	if err := repo.run("init", "-b", "main"); err != nil {
+		t.Fatalf("Failed to init: %v", err)
+	}
+	if err := repo.run("config", "user.name", "Test"); err != nil {
+		t.Fatalf("Failed to set user.name: %v", err)
+	}
+	if err := repo.run("config", "user.email", "test@test.com"); err != nil {
+		t.Fatalf("Failed to set user.email: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("# test\n"), 0644); err != nil {
+		t.Fatalf("Failed to write file: %v", err)
+	}
+	if err := repo.run("add", "."); err != nil {
+		t.Fatalf("Failed to add: %v", err)
+	}
+	if err := repo.run("commit", "-m", "init"); err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+	repo.AddRemote(t, "origin", "https://github.com/user/repo.git")
+
+	// SkipDir on the main repo means submodules inside it are never even visited.
+	// Verify only the main worktree is found.
+	entries, err := DiscoverGlobalWorktrees(baseDir)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if len(entries) != 1 {
+		t.Fatalf("Expected 1 entry (main only), got %d", len(entries))
+	}
+	if !entries[0].IsMain {
+		t.Error("Expected entry to be marked as main worktree")
+	}
 }
 
 func TestGetCurrentBranch_InvalidPath(t *testing.T) {
@@ -338,6 +469,78 @@ func TestFilterGlobalWorktrees_EmptyPattern(t *testing.T) {
 	matches := FilterGlobalWorktrees(entries, "")
 	if len(matches) != 2 {
 		t.Errorf("Expected all entries to match empty pattern, got %d", len(matches))
+	}
+}
+
+func TestIsSubmoduleGitDir(t *testing.T) {
+	tests := []struct {
+		name     string
+		gitDir   string
+		expected bool
+	}{
+		{
+			name:     "worktree gitdir",
+			gitDir:   "/path/to/repo/.git/worktrees/feature-branch",
+			expected: false,
+		},
+		{
+			name:     "relative worktree gitdir",
+			gitDir:   "../../.git/worktrees/feature-branch",
+			expected: false,
+		},
+		{
+			name:     "submodule gitdir",
+			gitDir:   "/path/to/repo/.git/modules/my-submodule",
+			expected: true,
+		},
+		{
+			name:     "relative submodule gitdir",
+			gitDir:   "../../.git/modules/my-submodule",
+			expected: true,
+		},
+		{
+			name:     "nested submodule gitdir",
+			gitDir:   "/path/to/repo/.git/modules/outer/modules/inner",
+			expected: true,
+		},
+		{
+			name:     "windows submodule gitdir",
+			gitDir:   "C:\\repo\\.git\\modules\\my-submodule",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isSubmoduleGitDir(tt.gitDir)
+			if result != tt.expected {
+				t.Errorf("isSubmoduleGitDir(%q) = %v, want %v", tt.gitDir, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDiscoverGlobalWorktrees_SkipsSubmodules(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a directory with a submodule-style .git file
+	submoduleDir := filepath.Join(tmpDir, "my-submodule")
+	if err := os.MkdirAll(submoduleDir, 0755); err != nil {
+		t.Fatalf("Failed to create submodule directory: %v", err)
+	}
+
+	gitContent := "gitdir: /path/to/repo/.git/modules/my-submodule"
+	if err := os.WriteFile(filepath.Join(submoduleDir, ".git"), []byte(gitContent), 0644); err != nil {
+		t.Fatalf("Failed to create .git file: %v", err)
+	}
+
+	entries, err := DiscoverGlobalWorktrees(tmpDir)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if len(entries) != 0 {
+		t.Errorf("Expected no entries (submodule should be skipped), got %d", len(entries))
 	}
 }
 

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -148,16 +148,14 @@ func TestDiscoverGlobalWorktrees_NoWorktrees(t *testing.T) {
 	}
 }
 
-func TestDiscoverGlobalWorktrees_IncludesMainWorktree(t *testing.T) {
-	baseDir := t.TempDir()
-
-	// Create a real git repo inside the base directory
-	repoDir := filepath.Join(baseDir, "github.com", "user", "repo", "main")
-	if err := os.MkdirAll(repoDir, 0755); err != nil {
+// initRepoAt creates and initializes a git repository at the given directory
+// with an initial commit and a remote.
+func initRepoAt(t *testing.T, dir, remoteURL string) *TestRepository {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0755); err != nil {
 		t.Fatalf("Failed to create repo directory: %v", err)
 	}
-
-	repo := &TestRepository{Path: repoDir}
+	repo := &TestRepository{Path: dir}
 	if err := repo.run("init", "-b", "main"); err != nil {
 		t.Fatalf("Failed to init: %v", err)
 	}
@@ -167,7 +165,7 @@ func TestDiscoverGlobalWorktrees_IncludesMainWorktree(t *testing.T) {
 	if err := repo.run("config", "user.email", "test@test.com"); err != nil {
 		t.Fatalf("Failed to set user.email: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("# test\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("# test\n"), 0644); err != nil {
 		t.Fatalf("Failed to write file: %v", err)
 	}
 	if err := repo.run("add", "."); err != nil {
@@ -176,7 +174,15 @@ func TestDiscoverGlobalWorktrees_IncludesMainWorktree(t *testing.T) {
 	if err := repo.run("commit", "-m", "init"); err != nil {
 		t.Fatalf("Failed to commit: %v", err)
 	}
-	repo.AddRemote(t, "origin", "https://github.com/user/repo.git")
+	repo.AddRemote(t, "origin", remoteURL)
+	return repo
+}
+
+func TestDiscoverGlobalWorktrees_IncludesMainWorktree(t *testing.T) {
+	baseDir := t.TempDir()
+
+	repoDir := filepath.Join(baseDir, "github.com", "user", "repo", "main")
+	initRepoAt(t, repoDir, "https://github.com/user/repo.git")
 
 	entries, err := DiscoverGlobalWorktrees(baseDir)
 	if err != nil {
@@ -198,32 +204,8 @@ func TestDiscoverGlobalWorktrees_IncludesMainWorktree(t *testing.T) {
 func TestDiscoverGlobalWorktrees_MainAndLinkedWorktrees(t *testing.T) {
 	baseDir := t.TempDir()
 
-	// Create main repo
 	repoDir := filepath.Join(baseDir, "github.com", "user", "repo", "main")
-	if err := os.MkdirAll(repoDir, 0755); err != nil {
-		t.Fatalf("Failed to create repo directory: %v", err)
-	}
-
-	repo := &TestRepository{Path: repoDir}
-	if err := repo.run("init", "-b", "main"); err != nil {
-		t.Fatalf("Failed to init: %v", err)
-	}
-	if err := repo.run("config", "user.name", "Test"); err != nil {
-		t.Fatalf("Failed to set user.name: %v", err)
-	}
-	if err := repo.run("config", "user.email", "test@test.com"); err != nil {
-		t.Fatalf("Failed to set user.email: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("# test\n"), 0644); err != nil {
-		t.Fatalf("Failed to write file: %v", err)
-	}
-	if err := repo.run("add", "."); err != nil {
-		t.Fatalf("Failed to add: %v", err)
-	}
-	if err := repo.run("commit", "-m", "init"); err != nil {
-		t.Fatalf("Failed to commit: %v", err)
-	}
-	repo.AddRemote(t, "origin", "https://github.com/user/repo.git")
+	repo := initRepoAt(t, repoDir, "https://github.com/user/repo.git")
 
 	// Create a branch and linked worktree
 	repo.CreateBranch(t, "feature")
@@ -258,38 +240,14 @@ func TestDiscoverGlobalWorktrees_MainAndLinkedWorktrees(t *testing.T) {
 	}
 }
 
-func TestDiscoverGlobalWorktrees_SkipsSubmodulesInsideMainRepo(t *testing.T) {
+func TestDiscoverGlobalWorktrees_DoesNotDescendIntoMainRepo(t *testing.T) {
 	baseDir := t.TempDir()
 
-	// Create a main repo with a fake submodule inside it
 	repoDir := filepath.Join(baseDir, "repo")
-	if err := os.MkdirAll(repoDir, 0755); err != nil {
-		t.Fatalf("Failed to create repo directory: %v", err)
-	}
+	initRepoAt(t, repoDir, "https://github.com/user/repo.git")
 
-	repo := &TestRepository{Path: repoDir}
-	if err := repo.run("init", "-b", "main"); err != nil {
-		t.Fatalf("Failed to init: %v", err)
-	}
-	if err := repo.run("config", "user.name", "Test"); err != nil {
-		t.Fatalf("Failed to set user.name: %v", err)
-	}
-	if err := repo.run("config", "user.email", "test@test.com"); err != nil {
-		t.Fatalf("Failed to set user.email: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("# test\n"), 0644); err != nil {
-		t.Fatalf("Failed to write file: %v", err)
-	}
-	if err := repo.run("add", "."); err != nil {
-		t.Fatalf("Failed to add: %v", err)
-	}
-	if err := repo.run("commit", "-m", "init"); err != nil {
-		t.Fatalf("Failed to commit: %v", err)
-	}
-	repo.AddRemote(t, "origin", "https://github.com/user/repo.git")
-
-	// SkipDir on the main repo means submodules inside it are never even visited.
-	// Verify only the main worktree is found.
+	// SkipDir on the main repo means nothing inside it (submodules, nested
+	// repos, etc.) is ever visited. Verify only the main worktree is found.
 	entries, err := DiscoverGlobalWorktrees(baseDir)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -447,13 +447,23 @@ func TestIsSubmoduleGitDir(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:     "submodule gitdir",
+			name:     "submodule in main worktree",
 			gitDir:   "/path/to/repo/.git/modules/my-submodule",
 			expected: true,
 		},
 		{
-			name:     "relative submodule gitdir",
+			name:     "relative submodule in main worktree",
 			gitDir:   "../../.git/modules/my-submodule",
+			expected: true,
+		},
+		{
+			name:     "submodule in linked worktree",
+			gitDir:   "../../../repo/.git/worktrees/feature/modules/cm/lwip",
+			expected: true,
+		},
+		{
+			name:     "nested submodule in linked worktree",
+			gitDir:   "../../../repo/.git/worktrees/feature/modules/third_party/xgrammar/xgrammar/modules/3rdparty/googletest",
 			expected: true,
 		},
 		{
@@ -464,7 +474,7 @@ func TestIsSubmoduleGitDir(t *testing.T) {
 		{
 			name:     "windows submodule gitdir",
 			gitDir:   "C:\\repo\\.git\\modules\\my-submodule",
-			expected: true,
+			expected: filepath.Separator == '\\', // only matches on Windows where ToSlash converts
 		},
 	}
 


### PR DESCRIPTION
## Summary

Fixes #95

- **Include main worktrees in global discovery**: `DiscoverGlobalWorktrees` now detects repos where `.git` is a directory (main worktree), not just linked worktrees where `.git` is a file. Sets `IsMain = true` and uses `filepath.SkipDir` to avoid descending into the repo.
- **Exclude submodules**: Submodule `.git` files point to `.git/modules/...` rather than `.git/worktrees/...`. Added `isSubmoduleGitDir` helper to detect and skip them.
- **Preserve glob patterns in config**: `expandConfigPaths` now skips `ExpandPath` for `repository_settings` entries containing glob characters (`*?[`), preventing `filepath.Abs()` from prepending the CWD and breaking pattern matching.

## Test plan

- [x] `make test` passes — all existing and new tests green
- [x] `make build` succeeds
- [x] New integration tests: `TestDiscoverGlobalWorktrees_IncludesMainWorktree`, `MainAndLinkedWorktrees`, `DoesNotDescendIntoMainRepo`, `SkipsSubmodules`
- [x] New unit tests: `TestIsSubmoduleGitDir` (6 cases), `TestRepositorySettingsGlobPatternPreserved`
- [x] Manual: `gwq list -g` shows main worktrees that were previously invisible
- [x] Manual: repos with submodules no longer show submodule entries in `gwq list -g`
- [x] Manual: `repository_settings` with glob patterns (e.g. `**/owner/repo`) correctly match

🤖 Generated with [Claude Code](https://claude.com/claude-code)