### PR TITLE
feat: support per-repository basedir override

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ tilde_home = true
 repository = "~/src/myproject"
 copy_files = ["templates/.env.example"]
 setup_commands = ["npm install"]
+basedir = "./worktrees"
 ```
 
 ### Key Settings
@@ -366,6 +367,7 @@ Configure automatic file copying and setup commands per repository. These settin
 repository = "~/src/myproject"
 copy_files = ["templates/.env.example", "config/*.json"]
 setup_commands = ["npm install", "npm run setup"]
+basedir = "./worktrees"
 ```
 
 #### Merge Behavior
@@ -436,6 +438,30 @@ For detailed configuration and shell function setup, see: [A Coding-Agent-Friend
 ```
 
 This structure prevents naming conflicts and preserves context about which repository a worktree belongs to.
+
+When a per-repository `basedir` is configured, worktrees are rooted there instead of the global basedir. The path within still follows the naming template:
+
+```
+~/src/myproject/
+├── worktrees/
+│   └── github.com/
+│       └── user/
+│           └── myproject/
+│               ├── feature-auth/
+│               └── feature-api/
+└── ...
+```
+
+To get a `<basedir>/<repo>/<branch>` structure, set `naming.template = "{{.Repository}}/{{.Branch}}"`. Note that `naming.template` is a global setting and affects all repositories:
+
+```
+~/src/myproject/
+├── worktrees/
+│   └── myproject/
+│       ├── feature-auth/
+│       └── feature-api/
+└── ...
+```
 
 ## Requirements
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -187,18 +187,27 @@ func expandConfigPaths(cfg *models.Config) error {
 		repo := cfg.RepositorySettings[i].Repository
 		// Skip path expansion for glob patterns — ExpandPath would prepend
 		// the CWD to relative globs like "**/owner/repo", breaking matching.
-		if strings.ContainsAny(repo, "*?[") {
-			continue
+		if !strings.ContainsAny(repo, "*?[") {
+			expandedPath, err = utils.ExpandPath(repo)
+			if err != nil {
+				return fmt.Errorf("failed to expand repository setting path: %w", err)
+			}
+			// Resolve symlinks for consistent path comparison with git-derived paths
+			if resolved, err := filepath.EvalSymlinks(expandedPath); err == nil {
+				expandedPath = resolved
+			}
+			cfg.RepositorySettings[i].Repository = expandedPath
 		}
-		expandedPath, err = utils.ExpandPath(repo)
-		if err != nil {
-			return fmt.Errorf("failed to expand repository setting path: %w", err)
+
+		// BaseDir is a destination path (not compared against git-derived paths),
+		// so symlink resolution is not needed here.
+		if baseDir := cfg.RepositorySettings[i].BaseDir; baseDir != "" {
+			expanded, err := utils.ExpandPath(baseDir)
+			if err != nil {
+				return fmt.Errorf("failed to expand repository basedir: %w", err)
+			}
+			cfg.RepositorySettings[i].BaseDir = expanded
 		}
-		// Resolve symlinks for consistent path comparison with git-derived paths
-		if resolved, err := filepath.EvalSymlinks(expandedPath); err == nil {
-			expandedPath = resolved
-		}
-		cfg.RepositorySettings[i].Repository = expandedPath
 	}
 	return nil
 }

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -205,26 +205,38 @@ func (m *Manager) generateWorktreePath(branch string) (string, error) {
 		return "", fmt.Errorf("failed to parse repository URL: %w", err)
 	}
 
+	// Determine effective base directory: per-repo setting overrides global
+	baseDir := m.config.Worktree.BaseDir
+	if len(m.config.RepositorySettings) > 0 {
+		repoRoot, err := m.git.GetMainRepositoryPath()
+		if err != nil {
+			return "", fmt.Errorf("failed to get repository path: %w", err)
+		}
+		if setting := findRepoSetting(m.config.RepositorySettings, repoRoot); setting != nil && setting.BaseDir != "" {
+			baseDir = setting.BaseDir
+		}
+	}
+
 	// Use template if configured, otherwise fall back to default URL hierarchy
 	if m.config.Naming.Template != "" {
 		// Create template processor
 		processor, err := template.New(m.config.Naming.Template, m.config.Naming.SanitizeChars)
 		if err != nil {
 			// Fall back to default hierarchy if template is invalid
-			return url.GenerateWorktreePath(m.config.Worktree.BaseDir, repoInfo, branch), nil
+			return url.GenerateWorktreePath(baseDir, repoInfo, branch), nil
 		}
 
 		// Generate path using template
-		path, err := processor.GeneratePath(m.config.Worktree.BaseDir, repoInfo, branch)
+		path, err := processor.GeneratePath(baseDir, repoInfo, branch)
 		if err != nil {
 			// Fall back to default hierarchy if template execution fails
-			return url.GenerateWorktreePath(m.config.Worktree.BaseDir, repoInfo, branch), nil
+			return url.GenerateWorktreePath(baseDir, repoInfo, branch), nil
 		}
 
 		return path, nil
 	}
 
 	// Fall back to default URL hierarchy
-	path := url.GenerateWorktreePath(m.config.Worktree.BaseDir, repoInfo, branch)
+	path := url.GenerateWorktreePath(baseDir, repoInfo, branch)
 	return path, nil
 }

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -1,6 +1,7 @@
 package worktree
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -20,6 +21,7 @@ type mockGit struct {
 	pruneError        error
 	deleteBranchError error
 	recentCommits     []models.CommitInfo
+	mainRepoPathError error
 }
 
 func (m *mockGit) ListWorktrees() ([]models.Worktree, error) {
@@ -81,6 +83,9 @@ func (m *mockGit) DeleteBranch(branch string, force bool) error {
 }
 
 func (m *mockGit) GetMainRepositoryPath() (string, error) {
+	if m.mainRepoPathError != nil {
+		return "", m.mainRepoPathError
+	}
 	if m.repoPath == "" {
 		return "/mock/repo/path", nil
 	}
@@ -421,10 +426,15 @@ func TestManagerValidateWorktreePath(t *testing.T) {
 
 func TestGenerateWorktreePath(t *testing.T) {
 	tests := []struct {
-		name       string
-		branch     string
-		repoName   string
-		wantSuffix string
+		name               string
+		branch             string
+		repoName           string
+		wantSuffix         string
+		repoPath           string
+		repositorySettings []models.RepositorySetting
+		mainRepoPathError  error
+		wantErr            bool
+		wantBaseDir        string // if non-empty, overrides "/base" in expected path
 	}{
 		{
 			name:       "BasicTemplate",
@@ -444,26 +454,72 @@ func TestGenerateWorktreePath(t *testing.T) {
 			repoName:   "myrepo",
 			wantSuffix: "github.com/test-user/test-repo/feature-test-new",
 		},
+		{
+			name:     "PerRepoBaseDir",
+			branch:   "feature/test",
+			repoName: "myrepo",
+			repoPath: "/mock/repo/path",
+			repositorySettings: []models.RepositorySetting{
+				{Repository: "/mock/repo/path", BaseDir: "/per-repo-base"},
+			},
+			wantSuffix:  "github.com/test-user/test-repo/feature-test",
+			wantBaseDir: "/per-repo-base",
+		},
+		{
+			name:     "PerRepoBaseDirEmpty",
+			branch:   "feature/test",
+			repoName: "myrepo",
+			repoPath: "/mock/repo/path",
+			repositorySettings: []models.RepositorySetting{
+				{Repository: "/mock/repo/path", BaseDir: ""},
+			},
+			wantSuffix: "github.com/test-user/test-repo/feature-test",
+		},
+		{
+			name:              "GetMainRepoPathError",
+			branch:            "feature/test",
+			repoName:          "myrepo",
+			mainRepoPathError: errors.New("git error"),
+			repositorySettings: []models.RepositorySetting{
+				{Repository: "/mock/repo/path", BaseDir: "/per-repo-base"},
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mockG := &mockGit{repoName: tt.repoName}
+			mockG := &mockGit{
+				repoName:          tt.repoName,
+				repoPath:          tt.repoPath,
+				mainRepoPathError: tt.mainRepoPathError,
+			}
 
 			config := &models.Config{
 				Worktree: models.WorktreeConfig{
 					BaseDir: "/base",
 				},
+				RepositorySettings: tt.repositorySettings,
 			}
 
 			m := New(mockG, config)
 
 			path, err := m.generateWorktreePath(tt.branch)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("generateWorktreePath() expected error, got nil")
+				}
+				return
+			}
 			if err != nil {
 				t.Fatalf("generateWorktreePath() error = %v", err)
 			}
 
-			expectedPath := filepath.Join("/base", tt.wantSuffix)
+			baseDir := "/base"
+			if tt.wantBaseDir != "" {
+				baseDir = tt.wantBaseDir
+			}
+			expectedPath := filepath.Join(baseDir, tt.wantSuffix)
 			if path != expectedPath {
 				t.Errorf("generateWorktreePath() = %s, want %s", path, expectedPath)
 			}

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -48,6 +48,7 @@ type RepositorySetting struct {
 	Repository    string   `mapstructure:"repository"`     // Path or pattern for repository
 	SetupCommands []string `mapstructure:"setup_commands"` // Commands to run in new worktree
 	CopyFiles     []string `mapstructure:"copy_files"`     // Files/globs to copy into new worktree
+	BaseDir       string   `mapstructure:"basedir"`        // Override global worktree.basedir for this repository
 }
 
 // WorktreeConfig contains worktree-specific configuration options.


### PR DESCRIPTION
## Summary
Fixes #97 

Add `basedir` field to `RepositorySetting` so individual repositories can override the global `worktree.basedir`.

### Motivation

When working with multiple repositories, it's sometimes desirable to place worktrees for a specific repository in a different base directory than the global default. For example, a project with its own `./worktrees/` convention alongside the repository root.

### Changes

- Add `BaseDir` field (`basedir` in config) to `RepositorySetting` in `pkg/models/models.go`
- Expand `basedir` path in `expandConfigPaths` (symlink resolution is intentionally skipped — this is a destination path, not compared against git-derived paths)
- In `generateWorktreePath`, use the per-repo `basedir` when a matching `repository_settings` entry has one set; fall back to global `worktree.basedir` otherwise
- Skip the `GetMainRepositoryPath` git call entirely when no `repository_settings` are configured

### Configuration example

```toml
[[repository_settings]]
repository = "~/src/myproject"
copy_files = ["templates/.env.example"]
setup_commands = ["npm install"]
basedir = "./worktrees"
```

## Test plan

- [x] `make test` — all tests pass
- [x] `make lint` — no issues
- [x] Manual: `gwq add` with no `repository_settings` → global `basedir` used, no extra git call
- [x] Manual: `gwq add` with `repository_settings.basedir` set → worktree created under per-repo basedir
- [x] Manual: `gwq add` with `repository_settings` but no `basedir` → falls back to global basedir

