### PR TITLE
fix: remove 404-prone release notes link from release PR body

### DIFF
--- a/.claude/skills/release-gwq/SKILL.md
+++ b/.claude/skills/release-gwq/SKILL.md
@@ -135,7 +135,7 @@ gh pr create --title "Release <version>" --body "$(cat <<'EOF'
 
 Release <version>
 
-See [docs/release-notes/<version>.md](https://github.com/d-kuro/gwq/blob/release/<version>/docs/release-notes/<version>.md) for details.
+See `docs/release-notes/<version>.md` for details.
 EOF
 )"
 ```


### PR DESCRIPTION
## Summary

- The `release-gwq` skill embedded an absolute blob URL pointing at the `release/<version>` branch in the PR body. Because the repo has `delete_branch_on_merge=true`, that URL 404s right after the PR is merged.
- A previous attempt to use the pushed-branch HEAD SHA would also dangle, since this repo uses squash / rebase merges and the branch-HEAD commit does not end up on `main`.
- Drop the hyperlink and reference the file path in plain text. Reviewers can still open the file from the PR Files changed tab, and there is no link left to break after merge.

## Test plan

- [ ] Next release PR body shows \`docs/release-notes/<version>.md\` as plain text (no hyperlink)
- [ ] Post-merge revisit of the PR body has no 404-ing link