### PR TITLE
Release v0.0.19

### DIFF
--- a/docs/release-notes/v0.0.19.md
+++ b/docs/release-notes/v0.0.19.md
@@ -1,0 +1,44 @@
+# Release v0.0.19
+
+## 🎉 New Features
+
+### Per-Repository Basedir Override (#100)
+
+Added a `basedir` field to `repository_settings` so individual repositories can override the global `worktree.basedir`. This is useful when a specific project follows a different convention (e.g., `./worktrees/` alongside the repository root) while keeping the global default for other repositories.
+
+Configuration example:
+
+```toml
+[[repository_settings]]
+repository = "~/src/myproject"
+copy_files = ["templates/.env.example"]
+setup_commands = ["npm install"]
+basedir = "./worktrees"
+```
+
+When no `repository_settings` are configured, the extra git call to resolve the main repository path is skipped entirely.
+
+## 🐛 Bug Fixes
+
+- Use absolute URL for release notes link in release PR body (#99)
+- Remove 404-prone release notes link from release PR body (#101)
+
+## 👥 Contributors
+
+- @ssshhhooota (#100)
+
+## 📦 Upgrade Instructions
+
+**Homebrew:**
+
+```bash
+brew upgrade d-kuro/tap/gwq
+```
+
+**Go:**
+
+```bash
+go install github.com/d-kuro/gwq/cmd/gwq@v0.0.19
+```
+
+**Full Changelog**: https://github.com/d-kuro/gwq/compare/v0.0.18...v0.0.19


### PR DESCRIPTION
## Summary

Release v0.0.19

See `docs/release-notes/v0.0.19.md` for details.