### PR TITLE
feat: auto-cd on 'gwq add' under shell integration (#103)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ gwq add -s feature/new-ui
 
 **Flags**: `-b` (new branch), `-i` (interactive), `-s` (stay), `-f` (force)
 
+> **Note**: With shell integration and `cd.launch_shell = false`, `-s` changes the current shell's directory instead of spawning a nested shell. Set `cd.auto_cd_on_add = true` to auto-cd after every `gwq add` without `-s`.
+
 ### `gwq list` (alias: `ls`)
 
 Display all worktrees.
@@ -279,7 +281,7 @@ gwq prune
 
 ## Shell Integration
 
-The completion scripts provide both tab completion and `gwq cd` shell integration. When `cd.launch_shell` is set to `false`, the completion script includes a shell wrapper that allows `gwq cd` to change the directory in the current shell without launching a new shell. PowerShell is currently not supported for shell integration.
+The completion scripts provide both tab completion and shell integration for `gwq cd` and `gwq add`. When `cd.launch_shell` is set to `false`, the completion script includes a shell wrapper that allows these commands to change the directory in the current shell without launching a new shell. For `gwq add`, this applies to `-s`/`--stay` and to every successful add when `cd.auto_cd_on_add = true`. PowerShell is currently not supported for shell integration.
 
 ### Tab Completion
 
@@ -336,6 +338,7 @@ sanitize_chars = { "/" = "-", ":" = "-" }
 
 [cd]
 launch_shell = false  # Use shell integration instead of launching a new shell
+auto_cd_on_add = false  # Auto-cd after 'gwq add' when shell integration is active
 
 [ui]
 icons = true
@@ -350,13 +353,14 @@ basedir = "./worktrees"
 
 ### Key Settings
 
-| Setting            | Description                           | Default                                            |
-| ------------------ | ------------------------------------- | -------------------------------------------------- |
-| `worktree.basedir` | Base directory for worktrees          | `~/worktrees`                                      |
-| `naming.template`  | Directory naming template             | `{{.Host}}/{{.Owner}}/{{.Repository}}/{{.Branch}}` |
-| `ui.tilde_home`    | Display `~` instead of full home path | `true`                                             |
-| `cd.launch_shell`  | Launch a new shell for `gwq cd` (set `false` for shell integration) | `true`                                             |
-| `ui.icons`         | Show icons in output                  | `true`                                             |
+| Setting             | Description                                                         | Default                                            |
+| ------------------- | ------------------------------------------------------------------- | -------------------------------------------------- |
+| `worktree.basedir`  | Base directory for worktrees                                        | `~/worktrees`                                      |
+| `naming.template`   | Directory naming template                                           | `{{.Host}}/{{.Owner}}/{{.Repository}}/{{.Branch}}` |
+| `ui.tilde_home`     | Display `~` instead of full home path                               | `true`                                             |
+| `cd.launch_shell`   | Launch a new shell for `gwq cd` (set `false` for shell integration) | `true`                                             |
+| `cd.auto_cd_on_add` | Auto-cd after `gwq add` when shell integration is active            | `false`                                            |
+| `ui.icons`          | Show icons in output                                                | `true`                                             |
 
 ### Per-Repository Setup
 

--- a/docs/release-notes/v0.0.20.md
+++ b/docs/release-notes/v0.0.20.md
@@ -1,0 +1,61 @@
+# Release v0.0.20
+
+## 🎉 New Features
+
+### Auto-cd on `gwq add` under shell integration (#103)
+
+When shell integration is enabled with `cd.launch_shell = false`, `gwq add` can now change the current shell's directory to the newly created worktree instead of spawning a nested sub-shell.
+
+Two mechanisms:
+
+1. **`--stay` (`-s`) now does a true cd** under shell integration. Previously it always spawned a nested shell, even when `cd.launch_shell = false`. Now it reuses the same `__GWQ_CD_SHIM` pipeline as `gwq cd` and cds the parent shell.
+2. **New `cd.auto_cd_on_add` config** (default `false`) — when `true` under shell integration, any successful `gwq add` auto-cds into the new worktree without needing `-s`.
+
+**Configuration:**
+
+```toml
+[cd]
+launch_shell = false
+auto_cd_on_add = true  # optional
+```
+
+**Setup** (same as `gwq cd`):
+
+```bash
+# bash (~/.bashrc)
+source <(gwq completion bash)
+
+# zsh (~/.zshrc)
+source <(gwq completion zsh)
+
+# fish (~/.config/fish/config.fish)
+gwq completion fish | source
+```
+
+After reloading your shell, `gwq add -s feature/x` (or plain `gwq add feature/x` with `auto_cd_on_add = true`) lands you inside the new worktree with no nested shell.
+
+### Behavior details
+
+- Outside shell integration (`cd.launch_shell = true` or wrapper not sourced), `--stay` still spawns a sub-shell as before.
+- Under shell integration, `gwq add` routes success messages to stderr so stdout can carry the worktree path for the wrapper to consume. Non-shim stdout behavior is unchanged, so `gwq add >log.txt` still captures the success lines.
+- PowerShell is completion-only (no shell integration).
+
+## 🐛 Bug Fixes
+
+- `gwq add --expires <invalid>` no longer creates a stray worktree. The duration is now parsed before the worktree is created, so invalid values fail fast.
+
+## 📦 Upgrade Instructions
+
+**Homebrew:**
+
+```bash
+brew upgrade d-kuro/tap/gwq
+```
+
+**Go:**
+
+```bash
+go install github.com/d-kuro/gwq/cmd/gwq@v0.0.20
+```
+
+**Full Changelog**: https://github.com/d-kuro/gwq/compare/v0.0.19...v0.0.20

--- a/internal/cmd/add.go
+++ b/internal/cmd/add.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"io"
+	"os"
 	"time"
 
 	"github.com/d-kuro/gwq/internal/duration"
@@ -100,49 +102,105 @@ func runAdd(cmd *cobra.Command, args []string) error {
 			}
 		}
 
+		// Validate --expires duration before creating the worktree so an
+		// invalid value does not leave a stray worktree behind. The actual
+		// ExpiresAt is computed after creation so the effective lifetime
+		// isn't shortened by setup time (e.g. repository_settings hooks).
+		var expiresDuration time.Duration
+		if addExpires != "" {
+			d, err := duration.Parse(addExpires)
+			if err != nil {
+				return fmt.Errorf("invalid --expires duration %q: %w", addExpires, err)
+			}
+			expiresDuration = d
+		}
+
 		worktreePath, err := ctx.WorktreeManager.Add(branch, path, addBranch)
 		if err != nil {
 			return err
 		}
 
-		ctx.Printer.PrintSuccess(fmt.Sprintf("Created worktree for branch '%s'", branch))
-
-		// Register worktree with expiration if --expires is specified
+		var expiresAt *time.Time
 		if addExpires != "" {
-			d, err := duration.Parse(addExpires)
-			if err != nil {
-				return fmt.Errorf("invalid expiration duration: %w", err)
-			}
-
-			expiresAt := time.Now().Add(d)
-
 			reg, err := registry.New()
 			if err != nil {
 				return fmt.Errorf("failed to open registry: %w", err)
 			}
 
-			// Get repository URL for the entry
 			repoURL, _ := ctx.Git.GetRepositoryURL()
+
+			t := time.Now().Add(expiresDuration)
+			expiresAt = &t
 
 			entry := &registry.WorktreeEntry{
 				Repository: repoURL,
 				Branch:     branch,
 				Path:       worktreePath,
 				IsMain:     false,
-				ExpiresAt:  &expiresAt,
+				ExpiresAt:  expiresAt,
 			}
 
 			if err := reg.Register(entry); err != nil {
 				return fmt.Errorf("failed to register worktree: %w", err)
 			}
-
-			ctx.Printer.PrintSuccess(fmt.Sprintf("Worktree expires at %s", expiresAt.Format(time.RFC3339)))
 		}
 
-		if addStay {
-			_ = LaunchShell(worktreePath)
-		}
-
+		handleAddPostCreate(
+			os.Stdout, os.Stderr,
+			isCdShimActive(),
+			ctx.Config.Cd.AutoCdOnAdd,
+			addResult{
+				Branch:    branch,
+				Path:      worktreePath,
+				Stay:      addStay,
+				ExpiresAt: expiresAt,
+			},
+			LaunchShell,
+		)
 		return nil
 	})(cmd, args)
+}
+
+// addResult carries the outcome of a successful `gwq add` into the
+// post-create output routing.
+type addResult struct {
+	Branch    string
+	Path      string
+	Stay      bool
+	ExpiresAt *time.Time
+}
+
+// handleAddPostCreate routes success messages and the worktree path to the
+// appropriate destinations after a successful `gwq add`.
+//
+// Under shell integration (inShim), success messages go to stderr and stdout
+// carries only the worktree path when a cd is wanted. When no cd is wanted,
+// stdout is left empty — the shell wrapper's "-n" guard then refuses to cd
+// into a success message.
+func handleAddPostCreate(
+	stdout, stderr io.Writer,
+	inShim, autoCdOnAdd bool,
+	r addResult,
+	launchShell func(string) error,
+) {
+	wantCd := r.Stay || autoCdOnAdd
+
+	msgDst := stdout
+	if inShim {
+		msgDst = stderr
+	}
+	_, _ = fmt.Fprintf(msgDst, "Created worktree for branch '%s'\n", r.Branch)
+	if r.ExpiresAt != nil {
+		_, _ = fmt.Fprintf(msgDst, "Worktree expires at %s\n", r.ExpiresAt.Format(time.RFC3339))
+	}
+
+	switch {
+	case inShim && wantCd:
+		_, _ = fmt.Fprintln(stdout, r.Path)
+	case inShim:
+		// stdout intentionally empty: shell wrapper's `if [[ -n "$__gwq_result" ]]`
+		// guard prevents an incorrect cd.
+	case r.Stay:
+		_ = launchShell(r.Path)
+	}
 }

--- a/internal/cmd/add_test.go
+++ b/internal/cmd/add_test.go
@@ -1,0 +1,115 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHandleAddPostCreate(t *testing.T) {
+	t.Parallel()
+
+	expAt := time.Now().Add(24 * time.Hour)
+
+	tests := []struct {
+		name           string
+		inShim         bool
+		autoCdOnAdd    bool
+		stay           bool
+		expiresAt      *time.Time
+		wantStdout     string
+		wantStderrHas  []string
+		wantShellCalls int
+	}{
+		{
+			name:           "shim+stay: path on stdout, msg on stderr",
+			inShim:         true,
+			stay:           true,
+			wantStdout:     "/wt/path\n",
+			wantStderrHas:  []string{"Created worktree for branch 'foo'"},
+			wantShellCalls: 0,
+		},
+		{
+			name:           "shim+auto_cd_on_add: path on stdout",
+			inShim:         true,
+			autoCdOnAdd:    true,
+			wantStdout:     "/wt/path\n",
+			wantStderrHas:  []string{"Created worktree for branch 'foo'"},
+			wantShellCalls: 0,
+		},
+		{
+			name:           "shim+neither: stdout strictly empty",
+			inShim:         true,
+			wantStdout:     "",
+			wantStderrHas:  []string{"Created worktree for branch 'foo'"},
+			wantShellCalls: 0,
+		},
+		{
+			name:           "shim+stay+expires: two stderr lines, one stdout line",
+			inShim:         true,
+			stay:           true,
+			expiresAt:      &expAt,
+			wantStdout:     "/wt/path\n",
+			wantStderrHas:  []string{"Created worktree", "Worktree expires at"},
+			wantShellCalls: 0,
+		},
+		{
+			name:           "nonshim+stay: launchShell called, msg on stdout",
+			stay:           true,
+			wantStdout:     "Created worktree for branch 'foo'\n",
+			wantShellCalls: 1,
+		},
+		{
+			name:           "nonshim+no stay: no shell, msg on stdout",
+			wantStdout:     "Created worktree for branch 'foo'\n",
+			wantShellCalls: 0,
+		},
+		{
+			name:           "auto_cd_on_add=true but no shim: no effect",
+			autoCdOnAdd:    true,
+			wantStdout:     "Created worktree for branch 'foo'\n",
+			wantShellCalls: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var stdout, stderr bytes.Buffer
+			shellCalls := 0
+			fakeLaunch := func(path string) error {
+				shellCalls++
+				if path != "/wt/path" {
+					t.Errorf("launchShell path = %q; want %q", path, "/wt/path")
+				}
+				return nil
+			}
+
+			handleAddPostCreate(
+				&stdout, &stderr,
+				tt.inShim, tt.autoCdOnAdd,
+				addResult{
+					Branch:    "foo",
+					Path:      "/wt/path",
+					Stay:      tt.stay,
+					ExpiresAt: tt.expiresAt,
+				},
+				fakeLaunch,
+			)
+
+			if got := stdout.String(); got != tt.wantStdout {
+				t.Errorf("stdout = %q; want %q", got, tt.wantStdout)
+			}
+			for _, sub := range tt.wantStderrHas {
+				if !strings.Contains(stderr.String(), sub) {
+					t.Errorf("stderr = %q; want to contain %q", stderr.String(), sub)
+				}
+			}
+			if shellCalls != tt.wantShellCalls {
+				t.Errorf("launchShell calls = %d; want %d", shellCalls, tt.wantShellCalls)
+			}
+		})
+	}
+}

--- a/internal/cmd/cd.go
+++ b/internal/cmd/cd.go
@@ -47,6 +47,16 @@ func init() {
 
 const envCdShim = "__GWQ_CD_SHIM"
 
+// isCdShimActive reports whether the current process is running under the
+// shell integration shim for cd/add. The wrapper sets __GWQ_CD_SHIM=1 before
+// re-invoking the binary, and the env var is authoritative: once the wrapper
+// is sourced, it will consume our stdout regardless of the current value of
+// cd.launch_shell (which may have been toggled mid-session without reloading
+// the shell).
+func isCdShimActive() bool {
+	return os.Getenv(envCdShim) == "1"
+}
+
 func runCd(cmd *cobra.Command, args []string) error {
 	cfg, err := config.Load()
 	if err != nil {
@@ -54,7 +64,7 @@ func runCd(cmd *cobra.Command, args []string) error {
 	}
 
 	// launch_shell=false without shell integration: show setup guidance
-	if !cfg.Cd.LaunchShell && os.Getenv(envCdShim) != "1" {
+	if !cfg.Cd.LaunchShell && !isCdShimActive() {
 		return fmt.Errorf(`'gwq cd' requires shell integration when cd.launch_shell is false.
 
 To enable shell integration, add this to your shell configuration:
@@ -92,7 +102,7 @@ Or, to use the old behavior (launching a new shell), run:
 	}
 
 	// Called from shell wrapper: print path to stdout
-	if !cfg.Cd.LaunchShell && os.Getenv(envCdShim) == "1" {
+	if isCdShimActive() {
 		fmt.Println(worktreePath)
 		return nil
 	}

--- a/internal/cmd/completion.go
+++ b/internal/cmd/completion.go
@@ -116,6 +116,7 @@ func getConfigKeyCompletions(_ *cobra.Command, args []string, toComplete string)
 		{"ui.icons", "Enable icon display"},
 		{"ui.tilde_home", "Display home directory as ~"},
 		{"cd.launch_shell", "Launch new shell on cd (default: true)"},
+		{"cd.auto_cd_on_add", "Auto-cd after 'gwq add' under shell integration (default: false)"},
 	}
 
 	var completions []string

--- a/internal/cmd/shellintegration_test.go
+++ b/internal/cmd/shellintegration_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
@@ -203,5 +204,60 @@ func TestCompletionCmd_Structure(t *testing.T) {
 		if !names[expected] {
 			t.Errorf("completion command should have %q subcommand", expected)
 		}
+	}
+}
+
+func TestCompletion_LaunchShellFalse_WrapsAdd(t *testing.T) {
+	tests := []struct {
+		name     string
+		shell    string
+		cmd      *cobra.Command
+		needle   string // substring that must appear in the wrapper to prove it dispatches both cd and add
+		fallback string // alternative substring acceptable (e.g., fish syntax)
+	}{
+		{
+			name:   "bash dispatches cd|add via __gwq_shim_cd",
+			shell:  "bash",
+			cmd:    completionBashCmd,
+			needle: "cd|add)",
+		},
+		{
+			name:   "zsh dispatches cd|add via __gwq_shim_cd",
+			shell:  "zsh",
+			cmd:    completionZshCmd,
+			needle: "cd|add)",
+		},
+		{
+			name:     "fish dispatches cd add via switch",
+			shell:    "fish",
+			cmd:      completionFishCmd,
+			needle:   "case cd add",
+			fallback: "__gwq_shim_cd",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			viper.Reset()
+			t.Cleanup(func() { viper.Reset() })
+			viper.Set("cd.launch_shell", false)
+
+			var buf bytes.Buffer
+			rootCmd.SetOut(&buf)
+			tt.cmd.SetOut(&buf)
+			rootCmd.SetArgs([]string{"completion", tt.shell})
+
+			if err := rootCmd.Execute(); err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+
+			output := buf.String()
+			if !strings.Contains(output, "__gwq_shim_cd") {
+				t.Errorf("%s wrapper should define __gwq_shim_cd helper", tt.shell)
+			}
+			if !strings.Contains(output, tt.needle) && (tt.fallback == "" || !strings.Contains(output, tt.fallback)) {
+				t.Errorf("%s wrapper should dispatch both cd and add (looking for %q or %q)", tt.shell, tt.needle, tt.fallback)
+			}
+		})
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -128,6 +128,7 @@ func Init() error {
 	viper.AddConfigPath(configDir)
 
 	viper.SetDefault("cd.launch_shell", true)
+	viper.SetDefault("cd.auto_cd_on_add", false)
 	viper.SetDefault("worktree.basedir", "~/worktrees")
 	viper.SetDefault("worktree.auto_mkdir", true)
 	viper.SetDefault("finder.preview", true)

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -35,8 +35,8 @@ func TestWriteWrapper_Zsh(t *testing.T) {
 	if !strings.Contains(output, "gwq()") {
 		t.Error("zsh wrapper should contain gwq() function")
 	}
-	if !strings.Contains(output, `[[ "$1" == "cd" ]]`) {
-		t.Error("zsh wrapper should use [[ ]] syntax")
+	if !strings.Contains(output, "cd|add)") {
+		t.Error("zsh wrapper should dispatch both cd and add")
 	}
 	if !strings.Contains(output, "__GWQ_CD_SHIM=1") {
 		t.Error("zsh wrapper should contain __GWQ_CD_SHIM=1")

--- a/internal/shell/templates/bash.tmpl
+++ b/internal/shell/templates/bash.tmpl
@@ -1,24 +1,31 @@
 
 # gwq shell integration
-# Enables 'gwq cd' to change the current shell's directory.
-{{.CommandName}}() {
-    if [ "$1" = "cd" ]; then
-        shift
-        # Pass through help flags directly to the binary
-        for __gwq_arg in "$@"; do
-            case "$__gwq_arg" in
-                --help|-h)
-                    command {{.CommandName}} cd "$@"
-                    return $?
-                    ;;
-            esac
-        done
-        local __gwq_result
-        __gwq_result="$(__GWQ_CD_SHIM=1 command {{.CommandName}} cd "$@")" || return $?
-        if [ -n "$__gwq_result" ]; then
-            builtin cd "$__gwq_result" || return $?
-        fi
-    else
-        command {{.CommandName}} "$@"
+# Enables 'gwq cd' and 'gwq add' to change the current shell's directory.
+__gwq_shim_cd() {
+    # Pass through help flags directly to the binary
+    for __gwq_arg in "$@"; do
+        case "$__gwq_arg" in
+            --help|-h)
+                command {{.CommandName}} "$@"
+                return $?
+                ;;
+        esac
+    done
+    local __gwq_result
+    __gwq_result="$(__GWQ_CD_SHIM=1 command {{.CommandName}} "$@")" || return $?
+    if [ -n "$__gwq_result" ]; then
+        builtin cd "$__gwq_result" || return $?
     fi
+    return 0
+}
+
+{{.CommandName}}() {
+    case "$1" in
+        cd|add)
+            __gwq_shim_cd "$@"
+            ;;
+        *)
+            command {{.CommandName}} "$@"
+            ;;
+    esac
 }

--- a/internal/shell/templates/fish.tmpl
+++ b/internal/shell/templates/fish.tmpl
@@ -1,26 +1,33 @@
 
 # gwq shell integration
-# Enables 'gwq cd' to change the current shell's directory.
-function {{.CommandName}} --wraps={{.CommandName}}
-    if test (count $argv) -gt 0; and test "$argv[1]" = "cd"
-        # Pass through help flags directly to the binary
-        for __gwq_arg in $argv[2..-1]
-            if test "$__gwq_arg" = "--help"; or test "$__gwq_arg" = "-h"
-                command {{.CommandName}} cd $argv[2..-1]
-                return $status
-            end
+# Enables 'gwq cd' and 'gwq add' to change the current shell's directory.
+function __gwq_shim_cd
+    # Pass through help flags directly to the binary
+    for __gwq_arg in $argv
+        if test "$__gwq_arg" = "--help"; or test "$__gwq_arg" = "-h"
+            command {{.CommandName}} $argv
+            return $status
         end
-        # Use set -lx for compatibility with fish < 3.1.
-        # Fish 3.1+ supports VAR=value command syntax (e.g., __GWQ_CD_SHIM=1 command ...).
-        set -lx __GWQ_CD_SHIM 1
-        set -l __gwq_result (command {{.CommandName}} cd $argv[2..-1])
-        set -l __gwq_st $status
-        if test $__gwq_st -eq 0; and test -n "$__gwq_result"
-            builtin cd $__gwq_result
-        else
-            return $__gwq_st
-        end
-    else
-        command {{.CommandName}} $argv
     end
+    # Use set -lx for compatibility with fish < 3.1.
+    # Fish 3.1+ supports VAR=value command syntax (e.g., __GWQ_CD_SHIM=1 command ...).
+    set -lx __GWQ_CD_SHIM 1
+    set -l __gwq_result (command {{.CommandName}} $argv)
+    set -l __gwq_st $status
+    if test $__gwq_st -eq 0; and test -n "$__gwq_result"
+        builtin cd $__gwq_result
+    else
+        return $__gwq_st
+    end
+end
+
+function {{.CommandName}} --wraps={{.CommandName}}
+    if test (count $argv) -gt 0
+        switch $argv[1]
+            case cd add
+                __gwq_shim_cd $argv
+                return $status
+        end
+    end
+    command {{.CommandName}} $argv
 end

--- a/internal/shell/templates/zsh.tmpl
+++ b/internal/shell/templates/zsh.tmpl
@@ -1,25 +1,32 @@
 
 # gwq shell integration
-# Enables 'gwq cd' to change the current shell's directory.
-{{.CommandName}}() {
-    if [[ "$1" == "cd" ]]; then
-        shift
-        # Pass through help flags directly to the binary
-        local __gwq_arg
-        for __gwq_arg in "$@"; do
-            case "$__gwq_arg" in
-                --help|-h)
-                    command {{.CommandName}} cd "$@"
-                    return $?
-                    ;;
-            esac
-        done
-        local __gwq_result
-        __gwq_result="$(__GWQ_CD_SHIM=1 command {{.CommandName}} cd "$@")" || return $?
-        if [[ -n "$__gwq_result" ]]; then
-            builtin cd "$__gwq_result" || return $?
-        fi
-    else
-        command {{.CommandName}} "$@"
+# Enables 'gwq cd' and 'gwq add' to change the current shell's directory.
+__gwq_shim_cd() {
+    # Pass through help flags directly to the binary
+    local __gwq_arg
+    for __gwq_arg in "$@"; do
+        case "$__gwq_arg" in
+            --help|-h)
+                command {{.CommandName}} "$@"
+                return $?
+                ;;
+        esac
+    done
+    local __gwq_result
+    __gwq_result="$(__GWQ_CD_SHIM=1 command {{.CommandName}} "$@")" || return $?
+    if [[ -n "$__gwq_result" ]]; then
+        builtin cd "$__gwq_result" || return $?
     fi
+    return 0
+}
+
+{{.CommandName}}() {
+    case "$1" in
+        cd|add)
+            __gwq_shim_cd "$@"
+            ;;
+        *)
+            command {{.CommandName}} "$@"
+            ;;
+    esac
 }

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -30,7 +30,8 @@ type CommitInfo struct {
 
 // CdConfig contains configuration for the cd command behavior.
 type CdConfig struct {
-	LaunchShell bool `mapstructure:"launch_shell"` // Whether to launch a new shell on cd
+	LaunchShell bool `mapstructure:"launch_shell"`   // Whether to launch a new shell on cd
+	AutoCdOnAdd bool `mapstructure:"auto_cd_on_add"` // Auto-cd after 'gwq add' under shell integration
 }
 
 // Config represents the application configuration.


### PR DESCRIPTION
## Summary

Closes #103.

When shell integration is enabled with `cd.launch_shell = false`, `gwq add` can now change the current shell's directory to the newly created worktree instead of spawning a nested sub-shell.

Two mechanisms, sharing the same `__GWQ_CD_SHIM` pipeline already used by `gwq cd`:

- **`--stay` (`-s`) now does a true cd** under shell integration. Previously it always spawned a nested sub-shell, even when `cd.launch_shell = false`.
- **New `cd.auto_cd_on_add` config** (default `false`) — when `true` under shell integration, every successful `gwq add` auto-cds into the new worktree without needing `-s`.

Outside shell integration, `--stay` still spawns a sub-shell as before — existing behavior is preserved.

### How it works

The bash, zsh, and fish completion wrappers now intercept both `cd` and `add` through a shared `__gwq_shim_cd` helper. The helper sets `__GWQ_CD_SHIM=1`, captures the worktree path from stdout, and runs `builtin cd`. In shim mode, `gwq add` routes success messages to stderr so stdout can carry the worktree path for the wrapper to consume. Non-shim stdout behavior is unchanged. PowerShell remains completion-only.

The shim check is env-var authoritative: once the wrapper is sourced, it honors `__GWQ_CD_SHIM=1` even if `cd.launch_shell` is toggled mid-session, avoiding a subtle failure mode where the wrapper would capture a success message as a path.

### Incidental fixes

- `gwq add --expires <invalid>` no longer creates a stray worktree. The duration string is validated before `WorktreeManager.Add`.
- The effective `ExpiresAt` is computed just before `registry.Register` so worktree creation time (including `repository_settings.setup_commands`) does not shorten the requested lifetime.

## Test plan

- [x] `make lint` — 0 issues
- [x] `go test -race ./...` — 446 passed
- [x] `make build` — succeeds
- [x] Manual E2E with bash completion (isolated `$HOME`, fresh git repo):
  - [x] `--stay` cds into worktree with no sub-shell nesting (`GWQ_SHELL_DEPTH` unset)
  - [x] `cd.auto_cd_on_add = true` cds without `-s`
  - [x] `cd.auto_cd_on_add = false` + no `-s` leaves PWD unchanged
  - [x] `--expires invalid` rejected with no stray worktree
  - [x] Shim mode: stdout = path, stderr = success message
  - [x] Shim env priority: wrapper active + `cd.launch_shell = true` still cds correctly
  - [x] `ExpiresAt` equals `registered_at + duration` (±14µs)
  - [x] Non-shim: `gwq add >log.txt` still captures the success message (stdout compat)