### PR TITLE
fix: gate local .gwq.toml behind a trust prompt (#105)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/ktr0731/go-fuzzyfinder v0.9.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
+	golang.org/x/term v0.39.0
 )
 
 require (
@@ -41,7 +42,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
-	golang.org/x/term v0.39.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 )

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@
 package config
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -44,24 +45,65 @@ func getLocalConfigPath() string {
 	return localConfigPath
 }
 
-// mergeLocalConfig merges the local config file (.gwq.toml) from the current directory.
-// Local config takes precedence over the global config.
-// For repository_settings, merging is done by the "repository" field as the key.
-func mergeLocalConfig() error {
-	localConfigPath := getLocalConfigPath()
-	if localConfigPath == "" {
+// mergeLocalConfig reads the local `.gwq.toml` from CWD and merges it into global viper.
+// Local config is treated as untrusted: it is only merged after the trust store confirms
+// (absolute path, sha256) match, or the user explicitly grants trust via the prompter.
+//
+//   - Non-regular files (directory / FIFO / socket / device) are skipped with a stderr warning.
+//   - If interactive is false (non-TTY), unknown files are skipped with a stderr warning.
+//   - On user rejection, the file is skipped (command continues, global config only).
+//   - Trust store write failures are non-fatal (merge proceeds with a stderr warning).
+//
+// For repository_settings, merging is done by the `repository` field as the key.
+func mergeLocalConfig(store *TrustStore, prompter trustPrompter, interactive bool) error {
+	rawPath := getLocalConfigPath()
+	if rawPath == "" {
 		return nil
 	}
 
-	localViper := viper.New()
-	localViper.SetConfigFile(localConfigPath)
-	localViper.SetConfigType(configType)
-
-	if err := localViper.ReadInConfig(); err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
-			return fmt.Errorf("failed to read local config %s: %w", localConfigPath, err)
-		}
+	absPath, err := normalizeConfigPath(rawPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "gwq: skipping local config: %v\n", err)
 		return nil
+	}
+
+	data, err := os.ReadFile(absPath)
+	if err != nil {
+		return fmt.Errorf("read local config %s: %w", absPath, err)
+	}
+	sum := computeSHA256(data)
+
+	if store == nil {
+		store, err = LoadTrustStore(defaultTrustStorePath())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "gwq: failed to load trust store (continuing empty): %v\n", err)
+			store = &TrustStore{path: defaultTrustStorePath()}
+		}
+	}
+
+	if !store.IsTrusted(absPath, sum) {
+		if !interactive {
+			fmt.Fprintf(os.Stderr, "gwq: skipping untrusted local config %s (non-interactive session)\n", absPath)
+			return nil
+		}
+		granted, err := prompter.PromptTrust(absPath, data)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "gwq: trust prompt failed, skipping local config: %v\n", err)
+			return nil
+		}
+		if !granted {
+			fmt.Fprintf(os.Stderr, "gwq: local config %s not trusted, skipping\n", absPath)
+			return nil
+		}
+		if err := store.Add(absPath, sum); err != nil {
+			fmt.Fprintf(os.Stderr, "gwq: failed to persist trust decision (continuing): %v\n", err)
+		}
+	}
+
+	localViper := viper.New()
+	localViper.SetConfigType(configType)
+	if err := localViper.ReadConfig(bytes.NewReader(data)); err != nil {
+		return fmt.Errorf("parse local config %s: %w", absPath, err)
 	}
 
 	for _, key := range localViper.AllKeys() {
@@ -155,8 +197,10 @@ func Init() error {
 		}
 	}
 
-	// Merge local config from current directory if present
-	if err := mergeLocalConfig(); err != nil {
+	// Local config is untrusted: the prompter gates its loading so a cloned
+	// repository cannot auto-execute setup_commands. The trust store is loaded
+	// lazily inside mergeLocalConfig — no disk read when .gwq.toml is absent.
+	if err := mergeLocalConfig(nil, newStdioPrompter(), isStdinInteractive()); err != nil {
 		return fmt.Errorf("failed to merge local config: %w", err)
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -24,6 +24,22 @@ func changeDir(t *testing.T, dir string) {
 	}
 }
 
+// stubPrompter is a trustPrompter for tests. response controls what PromptTrust
+// returns; callCount records how many times it was invoked.
+type stubPrompter struct {
+	response  bool
+	callCount int
+}
+
+func (s *stubPrompter) PromptTrust(string, []byte) (bool, error) {
+	s.callCount++
+	return s.response, nil
+}
+
+func trustingPrompter() trustPrompter {
+	return &stubPrompter{response: true}
+}
+
 func TestRepositorySettingsParsing(t *testing.T) {
 	viper.Reset()
 	viper.SetConfigType("toml")
@@ -381,7 +397,7 @@ func TestMergeLocalConfig(t *testing.T) {
 		viper.Set("worktree.basedir", "~/global-worktrees")
 
 		// Merge local config (no file exists)
-		if err := mergeLocalConfig(); err != nil {
+		if err := mergeLocalConfig(&TrustStore{}, trustingPrompter(), true); err != nil {
 			t.Fatalf("mergeLocalConfig() error = %v", err)
 		}
 
@@ -417,7 +433,7 @@ preview = false
 		viper.Set("finder.preview", true)
 
 		// Merge local config
-		if err := mergeLocalConfig(); err != nil {
+		if err := mergeLocalConfig(&TrustStore{}, trustingPrompter(), true); err != nil {
 			t.Fatalf("mergeLocalConfig() error = %v", err)
 		}
 
@@ -457,7 +473,7 @@ template = "{{.Repository}}/{{.Branch}}"
 		viper.Set("naming.sanitize_chars", map[string]string{"/": "-"})
 
 		// Merge local config
-		if err := mergeLocalConfig(); err != nil {
+		if err := mergeLocalConfig(&TrustStore{}, trustingPrompter(), true); err != nil {
 			t.Fatalf("mergeLocalConfig() error = %v", err)
 		}
 
@@ -513,7 +529,7 @@ copy_files = [".env.old"]
 		}
 
 		// Merge local config
-		if err := mergeLocalConfig(); err != nil {
+		if err := mergeLocalConfig(&TrustStore{}, trustingPrompter(), true); err != nil {
 			t.Fatalf("mergeLocalConfig() error = %v", err)
 		}
 
@@ -600,7 +616,7 @@ setup_commands = ["yarn install"]
 		}
 
 		// Merge local config
-		if err := mergeLocalConfig(); err != nil {
+		if err := mergeLocalConfig(&TrustStore{}, trustingPrompter(), true); err != nil {
 			t.Fatalf("mergeLocalConfig() error = %v", err)
 		}
 
@@ -710,7 +726,7 @@ preview = false
 	}
 
 	// Merge local config (simulating Init behavior)
-	if err := mergeLocalConfig(); err != nil {
+	if err := mergeLocalConfig(&TrustStore{}, trustingPrompter(), true); err != nil {
 		t.Fatalf("Failed to merge local config: %v", err)
 	}
 
@@ -774,4 +790,277 @@ func TestSetLocal(t *testing.T) {
 	if localViper.GetBool("finder.preview") != false {
 		t.Error("Local config should contain the set value (finder.preview = false)")
 	}
+}
+
+// writeLocalConfig places a .gwq.toml in tmpDir and chdir's into it.
+// Returns the canonical absolute path (symlinks resolved).
+func writeLocalConfig(t *testing.T, tmpDir string, content []byte) (absPath string, data []byte) {
+	t.Helper()
+	realDir, err := filepath.EvalSymlinks(tmpDir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
+	path := filepath.Join(realDir, ".gwq.toml")
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	changeDir(t, realDir)
+	return path, content
+}
+
+func TestMergeLocalConfigTrust(t *testing.T) {
+	localTOML := []byte(`
+[worktree]
+basedir = "~/local-worktrees"
+
+[[repository_settings]]
+repository = "/shared/repo"
+setup_commands = ["echo from-local"]
+copy_files = [".env.local"]
+`)
+
+	t.Run("trusted: preloaded entry skips prompt and merges", func(t *testing.T) {
+		viper.Reset()
+		t.Cleanup(func() { viper.Reset() })
+		viper.SetConfigType("toml")
+		viper.Set("worktree.basedir", "~/global-worktrees")
+
+		absPath, data := writeLocalConfig(t, t.TempDir(), localTOML)
+		store := &TrustStore{
+			entries: []trustEntry{{Path: absPath, SHA256: computeSHA256(data)}},
+		}
+		prompter := &stubPrompter{response: false} // would deny if called
+
+		if err := mergeLocalConfig(store, prompter, true); err != nil {
+			t.Fatalf("mergeLocalConfig: %v", err)
+		}
+		if prompter.callCount != 0 {
+			t.Errorf("prompter should not be called for trusted file, got %d calls", prompter.callCount)
+		}
+		if viper.GetString("worktree.basedir") != "~/local-worktrees" {
+			t.Errorf("merge did not run: worktree.basedir = %s", viper.GetString("worktree.basedir"))
+		}
+	})
+
+	t.Run("sha256 mismatch denied: merge skipped, copy_files/basedir not applied", func(t *testing.T) {
+		viper.Reset()
+		t.Cleanup(func() { viper.Reset() })
+		viper.SetConfigType("toml")
+		viper.Set("worktree.basedir", "~/global-worktrees")
+
+		absPath, _ := writeLocalConfig(t, t.TempDir(), localTOML)
+		// Registered but with a stale hash
+		store := &TrustStore{
+			entries: []trustEntry{{Path: absPath, SHA256: "stale-hash"}},
+		}
+		prompter := &stubPrompter{response: false}
+
+		if err := mergeLocalConfig(store, prompter, true); err != nil {
+			t.Fatalf("mergeLocalConfig: %v", err)
+		}
+		if prompter.callCount != 1 {
+			t.Errorf("prompter should be called once for stale hash, got %d", prompter.callCount)
+		}
+		if viper.GetString("worktree.basedir") != "~/global-worktrees" {
+			t.Errorf("merge should be skipped, basedir = %s", viper.GetString("worktree.basedir"))
+		}
+		// repository_settings from local config should NOT be in viper
+		if rs, ok := viper.Get("repository_settings").([]any); ok && len(rs) > 0 {
+			t.Errorf("repository_settings should not be applied on denial, got %v", rs)
+		}
+	})
+
+	t.Run("new file accepted: merge runs and store is updated", func(t *testing.T) {
+		viper.Reset()
+		t.Cleanup(func() { viper.Reset() })
+		viper.SetConfigType("toml")
+		viper.Set("worktree.basedir", "~/global-worktrees")
+
+		absPath, data := writeLocalConfig(t, t.TempDir(), localTOML)
+		store := &TrustStore{} // empty in-memory
+		prompter := &stubPrompter{response: true}
+
+		if err := mergeLocalConfig(store, prompter, true); err != nil {
+			t.Fatalf("mergeLocalConfig: %v", err)
+		}
+		if prompter.callCount != 1 {
+			t.Errorf("prompter should be called once, got %d", prompter.callCount)
+		}
+		if viper.GetString("worktree.basedir") != "~/local-worktrees" {
+			t.Errorf("merge should run: basedir = %s", viper.GetString("worktree.basedir"))
+		}
+		if !store.IsTrusted(absPath, computeSHA256(data)) {
+			t.Error("store should be updated after accept")
+		}
+	})
+
+	t.Run("non-interactive: untrusted file is skipped without prompt", func(t *testing.T) {
+		viper.Reset()
+		t.Cleanup(func() { viper.Reset() })
+		viper.SetConfigType("toml")
+		viper.Set("worktree.basedir", "~/global-worktrees")
+
+		writeLocalConfig(t, t.TempDir(), localTOML)
+		store := &TrustStore{}
+		prompter := &stubPrompter{response: true} // would accept if called
+
+		if err := mergeLocalConfig(store, prompter, false); err != nil {
+			t.Fatalf("mergeLocalConfig: %v", err)
+		}
+		if prompter.callCount != 0 {
+			t.Errorf("prompter must not be called in non-interactive mode, got %d calls", prompter.callCount)
+		}
+		if viper.GetString("worktree.basedir") != "~/global-worktrees" {
+			t.Errorf("merge must be skipped: basedir = %s", viper.GetString("worktree.basedir"))
+		}
+	})
+
+	t.Run("store write failure: merge proceeds with warning", func(t *testing.T) {
+		viper.Reset()
+		t.Cleanup(func() { viper.Reset() })
+		viper.SetConfigType("toml")
+		viper.Set("worktree.basedir", "~/global-worktrees")
+
+		writeLocalConfig(t, t.TempDir(), localTOML)
+		// Store path under a nonexistent parent → MkdirAll inside a non-writable
+		// parent fails. Use a path whose parent is a file, which will fail.
+		badParent := filepath.Join(t.TempDir(), "not-a-dir")
+		if err := os.WriteFile(badParent, []byte("x"), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		store := &TrustStore{path: filepath.Join(badParent, "child", "trusted.json")}
+		prompter := &stubPrompter{response: true}
+
+		if err := mergeLocalConfig(store, prompter, true); err != nil {
+			t.Fatalf("mergeLocalConfig should not error on store write failure: %v", err)
+		}
+		if viper.GetString("worktree.basedir") != "~/local-worktrees" {
+			t.Errorf("merge should still run: basedir = %s", viper.GetString("worktree.basedir"))
+		}
+	})
+
+	t.Run("not regular file: merge skipped, no error", func(t *testing.T) {
+		viper.Reset()
+		t.Cleanup(func() { viper.Reset() })
+		viper.SetConfigType("toml")
+		viper.Set("worktree.basedir", "~/global-worktrees")
+
+		tmpDir, err := filepath.EvalSymlinks(t.TempDir())
+		if err != nil {
+			t.Fatalf("EvalSymlinks: %v", err)
+		}
+		// Create .gwq.toml as a directory
+		if err := os.Mkdir(filepath.Join(tmpDir, ".gwq.toml"), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		changeDir(t, tmpDir)
+
+		store := &TrustStore{}
+		prompter := &stubPrompter{response: true}
+		if err := mergeLocalConfig(store, prompter, true); err != nil {
+			t.Fatalf("expected non-error on non-regular file, got %v", err)
+		}
+		if prompter.callCount != 0 {
+			t.Errorf("prompter should not be called for non-regular file, got %d", prompter.callCount)
+		}
+		if viper.GetString("worktree.basedir") != "~/global-worktrees" {
+			t.Errorf("merge should be skipped: basedir = %s", viper.GetString("worktree.basedir"))
+		}
+	})
+
+	t.Run("SetLocal invalidates trust: rewriting file changes sha256 and re-prompts", func(t *testing.T) {
+		viper.Reset()
+		t.Cleanup(func() { viper.Reset() })
+		viper.SetConfigType("toml")
+
+		absPath, data := writeLocalConfig(t, t.TempDir(), []byte("[worktree]\nbasedir = \"/v1\"\n"))
+		store := &TrustStore{
+			entries: []trustEntry{{Path: absPath, SHA256: computeSHA256(data)}},
+		}
+		prompter := &stubPrompter{response: true}
+
+		// First merge: trusted, no prompt
+		if err := mergeLocalConfig(store, prompter, true); err != nil {
+			t.Fatalf("first merge: %v", err)
+		}
+		if prompter.callCount != 0 {
+			t.Errorf("first merge should not prompt, got %d calls", prompter.callCount)
+		}
+
+		// Simulate SetLocal (which edits the file on disk).
+		if err := SetLocal("worktree.basedir", "/v2"); err != nil {
+			t.Fatalf("SetLocal: %v", err)
+		}
+
+		// Second merge: hash changed → re-prompt
+		if err := mergeLocalConfig(store, prompter, true); err != nil {
+			t.Fatalf("second merge: %v", err)
+		}
+		if prompter.callCount != 1 {
+			t.Errorf("second merge should prompt after SetLocal changed file, got %d calls", prompter.callCount)
+		}
+	})
+
+	// Denial must not leak repository_settings into the *models.Config returned
+	// by Load(), which is the struct the worktree Manager consumes to decide
+	// whether to run setup_commands.
+	t.Run("denied local config: Load() returns no leaked repository_settings", func(t *testing.T) {
+		viper.Reset()
+		t.Cleanup(func() { viper.Reset() })
+		viper.SetConfigType("toml")
+
+		writeLocalConfig(t, t.TempDir(), []byte(`
+[[repository_settings]]
+repository = "/mock/repo/path"
+setup_commands = ["sh -c 'touch /tmp/gwq-should-not-run'"]
+copy_files = [".env.evil"]
+`))
+		store := &TrustStore{}
+		prompter := &stubPrompter{response: false}
+
+		if err := mergeLocalConfig(store, prompter, true); err != nil {
+			t.Fatalf("mergeLocalConfig: %v", err)
+		}
+
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if len(cfg.RepositorySettings) != 0 {
+			t.Errorf("denied local config leaked %d repository_settings into Config: %+v",
+				len(cfg.RepositorySettings), cfg.RepositorySettings)
+		}
+	})
+
+	// Init() passes store=nil so the trust store is loaded lazily from disk
+	// only when a local .gwq.toml exists. Verify the lazy load runs and uses
+	// the on-disk store.
+	t.Run("nil store: lazy-load from disk", func(t *testing.T) {
+		viper.Reset()
+		t.Cleanup(func() { viper.Reset() })
+		viper.SetConfigType("toml")
+
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("USERPROFILE", home)
+
+		absPath, data := writeLocalConfig(t, t.TempDir(), []byte("[worktree]\nbasedir = \"/from-local\"\n"))
+
+		// Seed trust store on disk so lazy-load finds it trusted.
+		onDisk := &TrustStore{path: defaultTrustStorePath()}
+		if err := onDisk.Add(absPath, computeSHA256(data)); err != nil {
+			t.Fatalf("seed trust store: %v", err)
+		}
+
+		prompter := &stubPrompter{response: false}
+		if err := mergeLocalConfig(nil, prompter, true); err != nil {
+			t.Fatalf("mergeLocalConfig: %v", err)
+		}
+		if prompter.callCount != 0 {
+			t.Errorf("lazy-loaded trust store should have trusted the file, got %d prompt calls", prompter.callCount)
+		}
+		if viper.GetString("worktree.basedir") != "/from-local" {
+			t.Errorf("merge should run: basedir = %s", viper.GetString("worktree.basedir"))
+		}
+	})
 }

--- a/internal/config/trust.go
+++ b/internal/config/trust.go
@@ -126,7 +126,8 @@ func (s *TrustStore) save() error {
 		}
 	}
 
-	if err := os.MkdirAll(filepath.Dir(s.path), 0o755); err != nil {
+	dir := filepath.Dir(s.path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("create trust store dir: %w", err)
 	}
 
@@ -139,11 +140,14 @@ func (s *TrustStore) save() error {
 		return fmt.Errorf("marshal trust store: %w", err)
 	}
 
-	tmpPath := s.path + ".tmp"
-	f, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, trustStorePerm)
+	// os.CreateTemp uses O_CREATE|O_EXCL with a random suffix and mode 0600,
+	// so an attacker cannot pre-place a symlink at the temp path to redirect
+	// the write through.
+	f, err := os.CreateTemp(dir, filepath.Base(s.path)+".tmp-*")
 	if err != nil {
-		return fmt.Errorf("open trust store temp: %w", err)
+		return fmt.Errorf("create trust store temp: %w", err)
 	}
+	tmpPath := f.Name()
 	if _, err := f.Write(data); err != nil {
 		_ = f.Close()
 		_ = os.Remove(tmpPath)

--- a/internal/config/trust.go
+++ b/internal/config/trust.go
@@ -1,0 +1,269 @@
+package config
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"golang.org/x/term"
+)
+
+const (
+	trustStoreFilename = "trusted_configs.json"
+	trustStoreVersion  = 1
+	trustStorePerm     = 0o600
+	promptPreviewLimit = 4096 // Cap prompt file preview at 4 KiB to avoid flooding the terminal with a hostile or accidentally-large .gwq.toml, which could scroll the [y/N] prompt off-screen.
+)
+
+// trustPrompter asks the user whether to trust an untrusted local config.
+type trustPrompter interface {
+	PromptTrust(absPath string, content []byte) (bool, error)
+}
+
+// TrustStore manages trusted local `.gwq.toml` files keyed by (absolute path, sha256).
+// Zero value is useful: an empty, in-memory-only store.
+type TrustStore struct {
+	path    string
+	entries []trustEntry
+}
+
+type trustEntry struct {
+	Path      string    `json:"path"`
+	SHA256    string    `json:"sha256"`
+	TrustedAt time.Time `json:"trusted_at"`
+}
+
+type trustFile struct {
+	Version int          `json:"version"`
+	Entries []trustEntry `json:"entries"`
+}
+
+// LoadTrustStore reads the trust store from disk.
+// Missing file → empty store, not an error.
+// Malformed JSON or unknown version → empty store (non-fatal; startup must not be blocked).
+func LoadTrustStore(path string) (*TrustStore, error) {
+	s := &TrustStore{path: path}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return s, nil
+		}
+		return nil, fmt.Errorf("read trust store %s: %w", path, err)
+	}
+	if len(data) == 0 {
+		return s, nil
+	}
+
+	var tf trustFile
+	if err := json.Unmarshal(data, &tf); err != nil {
+		fmt.Fprintf(os.Stderr, "gwq: ignoring malformed trust store %s: %v\n", path, err)
+		return s, nil
+	}
+	if tf.Version != trustStoreVersion {
+		fmt.Fprintf(os.Stderr, "gwq: ignoring trust store %s with unknown version %d\n", path, tf.Version)
+		return s, nil
+	}
+
+	s.entries = tf.Entries
+	return s, nil
+}
+
+// IsTrusted reports whether (absPath, sha256) is registered.
+func (s *TrustStore) IsTrusted(absPath, sha256 string) bool {
+	if s == nil {
+		return false
+	}
+	for _, e := range s.entries {
+		if e.Path == absPath && e.SHA256 == sha256 {
+			return true
+		}
+	}
+	return false
+}
+
+// Add registers (absPath, sha256) as trusted and persists to disk with atomic rename.
+// Refuses to write if the trust store path is a symlink (anti-tampering).
+// If s.path is empty, the store is in-memory only and Add just updates entries.
+func (s *TrustStore) Add(absPath, sha256 string) error {
+	// Update or insert entry (dedupe by path; sha256 may differ).
+	now := time.Now().UTC()
+	replaced := false
+	for i := range s.entries {
+		if s.entries[i].Path == absPath {
+			s.entries[i].SHA256 = sha256
+			s.entries[i].TrustedAt = now
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		s.entries = append(s.entries, trustEntry{
+			Path:      absPath,
+			SHA256:    sha256,
+			TrustedAt: now,
+		})
+	}
+
+	if s.path == "" {
+		return nil
+	}
+	return s.save()
+}
+
+// save serializes entries and writes them atomically.
+func (s *TrustStore) save() error {
+	if info, err := os.Lstat(s.path); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to write trust store: %s is a symlink", s.path)
+		}
+	}
+
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o755); err != nil {
+		return fmt.Errorf("create trust store dir: %w", err)
+	}
+
+	tf := trustFile{
+		Version: trustStoreVersion,
+		Entries: s.entries,
+	}
+	data, err := json.MarshalIndent(tf, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal trust store: %w", err)
+	}
+
+	tmpPath := s.path + ".tmp"
+	f, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, trustStorePerm)
+	if err != nil {
+		return fmt.Errorf("open trust store temp: %w", err)
+	}
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("write trust store temp: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("close trust store temp: %w", err)
+	}
+	if err := os.Rename(tmpPath, s.path); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("rename trust store: %w", err)
+	}
+	return nil
+}
+
+// defaultTrustStorePath returns the canonical trust store location under the gwq config dir.
+func defaultTrustStorePath() string {
+	return filepath.Join(getConfigDir(), trustStoreFilename)
+}
+
+// computeSHA256 returns the hex-encoded SHA-256 of data.
+// Bytes-only variant (intentional: no path-taking helper, to avoid TOCTOU between hash and parse).
+func computeSHA256(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+// normalizeConfigPath returns the absolute, symlink-resolved path for a local config file.
+// Returns an error if the resolved target is not a regular file (directory / FIFO / socket / device).
+func normalizeConfigPath(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("abs path %s: %w", path, err)
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return "", fmt.Errorf("resolve symlinks %s: %w", abs, err)
+	}
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return "", fmt.Errorf("stat %s: %w", resolved, err)
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("%s is not a regular file (mode %s)", resolved, info.Mode())
+	}
+	return resolved, nil
+}
+
+// isStdinInteractive reports whether stdin is attached to a terminal.
+func isStdinInteractive() bool {
+	return term.IsTerminal(int(os.Stdin.Fd()))
+}
+
+// stdioPrompter asks the user via stdin/stderr. Never writes to stdout —
+// shell integration (`gwq cd`, completion) uses stdout as a protocol.
+type stdioPrompter struct {
+	in  io.Reader
+	out io.Writer
+}
+
+func newStdioPrompter() *stdioPrompter {
+	return &stdioPrompter{in: os.Stdin, out: os.Stderr}
+}
+
+// PromptTrust shows the file contents and asks for trust confirmation.
+// Returns true only on "y" / "yes" (case-insensitive). EOF / error → false.
+//
+// The file content is untrusted input. Control bytes (C0/C1 escapes, DEL, CR)
+// are escaped before output so ANSI/OSC sequences in a malicious .gwq.toml
+// cannot clear the screen, move the cursor, or forge the [y/N] prompt.
+func (p *stdioPrompter) PromptTrust(absPath string, content []byte) (bool, error) {
+	preview := content
+	truncated := false
+	if len(preview) > promptPreviewLimit {
+		preview = preview[:promptPreviewLimit]
+		truncated = true
+	}
+
+	var b strings.Builder
+	b.WriteString("\ngwq: untrusted local config detected:\n")
+	fmt.Fprintf(&b, "  path: %s\n", sanitizeForTerminal(absPath))
+	fmt.Fprintf(&b, "  size: %d bytes\n\n", len(content))
+	b.WriteString("--- file contents ---\n")
+	b.WriteString(strings.TrimRight(sanitizeForTerminal(string(preview)), "\n"))
+	if truncated {
+		fmt.Fprintf(&b, "\n... (truncated, showing first %d of %d bytes)", promptPreviewLimit, len(content))
+	}
+	b.WriteString("\n--------------------\n\n")
+	b.WriteString("Trust this file and load it? [y/N]: ")
+	if _, err := io.WriteString(p.out, b.String()); err != nil {
+		return false, fmt.Errorf("write prompt: %w", err)
+	}
+
+	var response string
+	if _, err := fmt.Fscanln(p.in, &response); err != nil {
+		return false, nil
+	}
+	response = strings.ToLower(strings.TrimSpace(response))
+	return response == "y" || response == "yes", nil
+}
+
+// sanitizeForTerminal replaces terminal control characters with a visible
+// `\xHH` escape so untrusted input cannot inject ANSI/OSC sequences, overwrite
+// output via carriage return, or otherwise forge the surrounding prompt. Tab
+// and newline pass through unchanged since they are needed for normal layout.
+// C1 controls (U+0080–U+009F) are also escaped because modern terminals still
+// honor them when they arrive via UTF-8 (`0xC2 0x80`..`0xC2 0x9F`).
+func sanitizeForTerminal(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch {
+		case r == '\n' || r == '\t':
+			b.WriteRune(r)
+		case r < 0x20 || (r >= 0x7f && r <= 0x9f):
+			fmt.Fprintf(&b, "\\x%02x", r)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}

--- a/internal/config/trust_test.go
+++ b/internal/config/trust_test.go
@@ -1,0 +1,543 @@
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+func TestComputeSHA256(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+		want string
+	}{
+		{
+			name: "empty",
+			data: []byte{},
+			want: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		},
+		{
+			name: "hello",
+			data: []byte("hello"),
+			want: "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+		},
+		{
+			name: "multiline",
+			data: []byte("line1\nline2\n"),
+			want: "2751a3a2f303ad21752038085e2b8c5f98ecff61a2e4ebbd43506a941725be80",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := computeSHA256(tt.data); got != tt.want {
+				t.Errorf("computeSHA256(%q) = %s, want %s", tt.data, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoadTrustStore(t *testing.T) {
+	validJSON := func(t *testing.T) []byte {
+		t.Helper()
+		data, err := json.Marshal(trustFile{
+			Version: trustStoreVersion,
+			Entries: []trustEntry{
+				{Path: "/abs/path/.gwq.toml", SHA256: "abc"},
+			},
+		})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		return data
+	}
+
+	tests := []struct {
+		name       string
+		writeBytes func(t *testing.T) ([]byte, bool) // (data, write)
+		wantLen    int
+	}{
+		{
+			name: "missing file",
+			writeBytes: func(*testing.T) ([]byte, bool) {
+				return nil, false
+			},
+			wantLen: 0,
+		},
+		{
+			name: "empty file",
+			writeBytes: func(*testing.T) ([]byte, bool) {
+				return []byte{}, true
+			},
+			wantLen: 0,
+		},
+		{
+			name:       "valid json",
+			writeBytes: func(t *testing.T) ([]byte, bool) { return validJSON(t), true },
+			wantLen:    1,
+		},
+		{
+			name: "malformed json",
+			writeBytes: func(*testing.T) ([]byte, bool) {
+				return []byte("{not json"), true
+			},
+			wantLen: 0,
+		},
+		{
+			name: "unknown version",
+			writeBytes: func(t *testing.T) ([]byte, bool) {
+				data, err := json.Marshal(trustFile{Version: 999, Entries: []trustEntry{{Path: "/x"}}})
+				if err != nil {
+					t.Fatalf("marshal: %v", err)
+				}
+				return data, true
+			},
+			wantLen: 0,
+		},
+		{
+			name: "top-level array (legacy shape)",
+			writeBytes: func(*testing.T) ([]byte, bool) {
+				return []byte(`[{"path":"/x","sha256":"y"}]`), true
+			},
+			wantLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "trusted_configs.json")
+			if data, write := tt.writeBytes(t); write {
+				if err := os.WriteFile(path, data, trustStorePerm); err != nil {
+					t.Fatalf("write: %v", err)
+				}
+			}
+			s, err := LoadTrustStore(path)
+			if err != nil {
+				t.Fatalf("LoadTrustStore() error = %v", err)
+			}
+			if got := len(s.entries); got != tt.wantLen {
+				t.Errorf("entries len = %d, want %d", got, tt.wantLen)
+			}
+			if s.path != path {
+				t.Errorf("path = %s, want %s", s.path, path)
+			}
+		})
+	}
+}
+
+func TestTrustStore_IsTrusted(t *testing.T) {
+	s := &TrustStore{
+		entries: []trustEntry{
+			{Path: "/a", SHA256: "hash-a"},
+			{Path: "/b", SHA256: "hash-b"},
+		},
+	}
+	tests := []struct {
+		name string
+		path string
+		sha  string
+		want bool
+	}{
+		{"match a", "/a", "hash-a", true},
+		{"match b", "/b", "hash-b", true},
+		{"path mismatch", "/c", "hash-a", false},
+		{"sha mismatch", "/a", "other", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := s.IsTrusted(tt.path, tt.sha); got != tt.want {
+				t.Errorf("IsTrusted(%s, %s) = %v, want %v", tt.path, tt.sha, got, tt.want)
+			}
+		})
+	}
+
+	t.Run("empty store", func(t *testing.T) {
+		var empty TrustStore
+		if empty.IsTrusted("/a", "x") {
+			t.Error("empty store should not trust anything")
+		}
+	})
+
+	t.Run("nil store", func(t *testing.T) {
+		var nilStore *TrustStore
+		if nilStore.IsTrusted("/a", "x") {
+			t.Error("nil store should not trust anything")
+		}
+	})
+}
+
+func TestTrustStore_Add_RoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "trusted_configs.json")
+	s, err := LoadTrustStore(path)
+	if err != nil {
+		t.Fatalf("LoadTrustStore: %v", err)
+	}
+	if err := s.Add("/abs/foo", "sha-foo"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := s.Add("/abs/bar", "sha-bar"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != trustStorePerm {
+		t.Errorf("perm = %o, want %o", perm, trustStorePerm)
+	}
+
+	reloaded, err := LoadTrustStore(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if len(reloaded.entries) != 2 {
+		t.Fatalf("entries len = %d, want 2", len(reloaded.entries))
+	}
+	if !reloaded.IsTrusted("/abs/foo", "sha-foo") {
+		t.Error("expected /abs/foo to be trusted")
+	}
+	if !reloaded.IsTrusted("/abs/bar", "sha-bar") {
+		t.Error("expected /abs/bar to be trusted")
+	}
+}
+
+func TestTrustStore_Add_DedupeUpdatesHash(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "trusted_configs.json")
+	s, _ := LoadTrustStore(path)
+
+	if err := s.Add("/abs/foo", "hash-v1"); err != nil {
+		t.Fatalf("Add v1: %v", err)
+	}
+	if err := s.Add("/abs/foo", "hash-v2"); err != nil {
+		t.Fatalf("Add v2: %v", err)
+	}
+
+	if len(s.entries) != 1 {
+		t.Errorf("entries len = %d, want 1 (should dedupe by path)", len(s.entries))
+	}
+	if !s.IsTrusted("/abs/foo", "hash-v2") {
+		t.Error("expected updated hash to be trusted")
+	}
+	if s.IsTrusted("/abs/foo", "hash-v1") {
+		t.Error("old hash should no longer be trusted after update")
+	}
+}
+
+func TestTrustStore_Add_InMemory(t *testing.T) {
+	var s TrustStore // zero value: path == "" → in-memory only
+	if err := s.Add("/abs/foo", "sha"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if !s.IsTrusted("/abs/foo", "sha") {
+		t.Error("expected in-memory add to work")
+	}
+}
+
+func TestTrustStore_Add_AtomicNoTempLeftover(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "trusted_configs.json")
+	s, _ := LoadTrustStore(path)
+	if err := s.Add("/abs/foo", "sha"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Errorf("stale temp file left behind: %s", e.Name())
+		}
+	}
+}
+
+func TestTrustStore_Add_SymlinkRejected(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink test not reliable on Windows")
+	}
+	dir := t.TempDir()
+	realTarget := filepath.Join(dir, "evil_target.json")
+	if err := os.WriteFile(realTarget, []byte("original"), 0o644); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+
+	storePath := filepath.Join(dir, "trusted_configs.json")
+	if err := os.Symlink(realTarget, storePath); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	s := &TrustStore{path: storePath}
+	err := s.Add("/abs/foo", "sha")
+	if err == nil {
+		t.Fatal("expected Add to reject symlink target")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Errorf("error should mention symlink, got: %v", err)
+	}
+
+	data, readErr := os.ReadFile(realTarget)
+	if readErr != nil {
+		t.Fatalf("read target: %v", readErr)
+	}
+	if string(data) != "original" {
+		t.Errorf("symlink target was modified: %q", data)
+	}
+}
+
+func TestNormalizeConfigPath(t *testing.T) {
+	dir := t.TempDir()
+	realDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(dir): %v", err)
+	}
+
+	regularFile := filepath.Join(dir, "regular.toml")
+	if err := os.WriteFile(regularFile, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	subdir := filepath.Join(dir, "subdir")
+	if err := os.Mkdir(subdir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	symlinkFile := filepath.Join(dir, "link.toml")
+	if err := os.Symlink(regularFile, symlinkFile); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	t.Run("regular file", func(t *testing.T) {
+		got, err := normalizeConfigPath(regularFile)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		want := filepath.Join(realDir, "regular.toml")
+		if got != want {
+			t.Errorf("got %s, want %s", got, want)
+		}
+	})
+
+	t.Run("symlink to regular file", func(t *testing.T) {
+		got, err := normalizeConfigPath(symlinkFile)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		want := filepath.Join(realDir, "regular.toml")
+		if got != want {
+			t.Errorf("got %s, want %s", got, want)
+		}
+	})
+
+	t.Run("directory rejected", func(t *testing.T) {
+		_, err := normalizeConfigPath(subdir)
+		if err == nil {
+			t.Fatal("expected error for directory")
+		}
+		if !strings.Contains(err.Error(), "not a regular file") {
+			t.Errorf("error should mention regular file: %v", err)
+		}
+	})
+
+	t.Run("nonexistent path", func(t *testing.T) {
+		_, err := normalizeConfigPath(filepath.Join(dir, "does-not-exist"))
+		if err == nil {
+			t.Fatal("expected error for nonexistent path")
+		}
+	})
+
+	if runtime.GOOS != "windows" {
+		t.Run("FIFO rejected", func(t *testing.T) {
+			fifoPath := filepath.Join(dir, "fifo")
+			if err := syscall.Mkfifo(fifoPath, 0o600); err != nil {
+				t.Skipf("Mkfifo unavailable: %v", err)
+			}
+			_, err := normalizeConfigPath(fifoPath)
+			if err == nil {
+				t.Fatal("expected FIFO to be rejected")
+			}
+			if !strings.Contains(err.Error(), "not a regular file") {
+				t.Errorf("error should mention regular file: %v", err)
+			}
+		})
+	}
+}
+
+func TestStdioPrompter_PromptTrust(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"y lowercase", "y\n", true},
+		{"Y uppercase", "Y\n", true},
+		{"yes lowercase", "yes\n", true},
+		{"YES uppercase", "YES\n", true},
+		{"n", "n\n", false},
+		{"empty line", "\n", false},
+		{"arbitrary string", "maybe\n", false},
+		{"EOF", "", false},
+		{"leading whitespace", "  y\n", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out strings.Builder
+			p := &stdioPrompter{
+				in:  strings.NewReader(tt.input),
+				out: &out,
+			}
+			got, err := p.PromptTrust("/abs/foo/.gwq.toml", []byte("setup_commands = [\"x\"]"))
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("PromptTrust(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+			if !strings.Contains(out.String(), "/abs/foo/.gwq.toml") {
+				t.Error("prompt should include path")
+			}
+			if !strings.Contains(out.String(), "setup_commands") {
+				t.Error("prompt should include file contents")
+			}
+		})
+	}
+
+	t.Run("oversized content is truncated", func(t *testing.T) {
+		var out strings.Builder
+		p := &stdioPrompter{
+			in:  strings.NewReader("n\n"),
+			out: &out,
+		}
+		big := bytes.Repeat([]byte("A"), promptPreviewLimit*2)
+		if _, err := p.PromptTrust("/abs/big.toml", big); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		display := out.String()
+		if !strings.Contains(display, "truncated") {
+			t.Error("prompt should announce truncation for oversized content")
+		}
+		if strings.Count(display, "A") >= len(big) {
+			t.Errorf("prompt should not contain full oversized payload (%d bytes)", len(big))
+		}
+	})
+
+	t.Run("control bytes in content are escaped", func(t *testing.T) {
+		var out strings.Builder
+		p := &stdioPrompter{in: strings.NewReader("n\n"), out: &out}
+		hostile := []byte("safe\n\x1b[2J\x1b]0;forged title\x07\rinjected\x7fend")
+		if _, err := p.PromptTrust("/abs/evil.toml", hostile); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		display := out.String()
+		// Raw ESC (0x1b), BEL (0x07), CR (0x0d), DEL (0x7f) must not appear.
+		for _, b := range []byte{0x1b, 0x07, 0x0d, 0x7f} {
+			if strings.ContainsRune(display, rune(b)) {
+				t.Errorf("raw control byte 0x%02x leaked into prompt output", b)
+			}
+		}
+		// Escaped forms should be visible instead.
+		for _, want := range []string{`\x1b`, `\x07`, `\x0d`, `\x7f`} {
+			if !strings.Contains(display, want) {
+				t.Errorf("expected %q in escaped output, got: %q", want, display)
+			}
+		}
+		if !strings.Contains(display, "safe") || !strings.Contains(display, "injected") {
+			t.Error("printable text should still appear around the escaped bytes")
+		}
+	})
+
+	t.Run("control bytes in path are escaped", func(t *testing.T) {
+		var out strings.Builder
+		p := &stdioPrompter{in: strings.NewReader("n\n"), out: &out}
+		if _, err := p.PromptTrust("/tmp/\x1b[2K/.gwq.toml", []byte("x")); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if strings.ContainsRune(out.String(), 0x1b) {
+			t.Error("raw ESC in path leaked into prompt output")
+		}
+		if !strings.Contains(out.String(), `\x1b`) {
+			t.Errorf("expected escaped ESC in path, got: %q", out.String())
+		}
+	})
+}
+
+func TestSanitizeForTerminal(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain ascii", "hello world", "hello world"},
+		{"tab and newline kept", "a\tb\nc", "a\tb\nc"},
+		{"ansi escape", "pre\x1b[31mred\x1b[0mpost", `pre\x1b[31mred\x1b[0mpost`},
+		{"carriage return", "a\rb", `a\x0db`},
+		{"BEL and DEL", "x\x07y\x7fz", `x\x07y\x7fz`},
+		{"unicode preserved", "日本語", "日本語"},
+		{"C1 control via utf8", "a\u009bb", `a\x9bb`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sanitizeForTerminal(tt.in); got != tt.want {
+				t.Errorf("sanitizeForTerminal(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDefaultTrustStorePath(t *testing.T) {
+	t.Setenv("HOME", "/tmp/fake-home")
+	got := defaultTrustStorePath()
+	if !strings.HasSuffix(got, "trusted_configs.json") {
+		t.Errorf("defaultTrustStorePath() = %s, want suffix trusted_configs.json", got)
+	}
+	if !strings.Contains(got, "gwq") {
+		t.Errorf("defaultTrustStorePath() = %s, want to contain gwq", got)
+	}
+}
+
+func FuzzLoadTrustStore(f *testing.F) {
+	// Seed with a valid JSON document.
+	validJSON, err := json.Marshal(trustFile{
+		Version: trustStoreVersion,
+		Entries: []trustEntry{{Path: "/x", SHA256: "abc"}},
+	})
+	if err != nil {
+		f.Fatalf("seed marshal: %v", err)
+	}
+	f.Add(validJSON)
+	f.Add([]byte(""))
+	f.Add([]byte("{"))
+	f.Add([]byte(`{"version":0,"entries":[]}`))
+	f.Add([]byte(`{"version":1}`))
+	f.Add([]byte(`{"version":1,"entries":[{}]}`))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		path := filepath.Join(t.TempDir(), "trusted_configs.json")
+		if err := os.WriteFile(path, data, trustStorePerm); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		s, err := LoadTrustStore(path)
+		if err != nil {
+			// Load must not return an error for arbitrary bytes;
+			// malformed input falls back to empty store.
+			t.Fatalf("LoadTrustStore returned error for fuzz input: %v", err)
+		}
+		// Any loaded entry must be self-consistent: IsTrusted on the same
+		// (path, sha) pair must return true. Breaking this would mean an
+		// attacker could inject an entry that's stored but ineffective, or
+		// vice versa.
+		for _, e := range s.entries {
+			if !s.IsTrusted(e.Path, e.SHA256) {
+				t.Errorf("loaded entry not reported as trusted: %+v", e)
+			}
+		}
+	})
+}

--- a/internal/config/trust_test.go
+++ b/internal/config/trust_test.go
@@ -253,9 +253,70 @@ func TestTrustStore_Add_AtomicNoTempLeftover(t *testing.T) {
 		t.Fatalf("ReadDir: %v", err)
 	}
 	for _, e := range entries {
-		if strings.HasSuffix(e.Name(), ".tmp") {
+		if strings.Contains(e.Name(), ".tmp") {
 			t.Errorf("stale temp file left behind: %s", e.Name())
 		}
+	}
+}
+
+// TestTrustStore_Add_TempSymlinkAttackResisted ensures that save() cannot be
+// tricked into following a pre-placed symlink at the temp path and clobbering
+// an arbitrary file. os.CreateTemp uses O_CREATE|O_EXCL with a random suffix,
+// so decoys at predictable names are never opened for write.
+func TestTrustStore_Add_TempSymlinkAttackResisted(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink test not reliable on Windows")
+	}
+	dir := t.TempDir()
+	victimDir := t.TempDir()
+	victim := filepath.Join(victimDir, "victim")
+	if err := os.WriteFile(victim, []byte("DO-NOT-OVERWRITE"), 0o600); err != nil {
+		t.Fatalf("write victim: %v", err)
+	}
+
+	// Plant decoy symlinks at names an attacker might guess.
+	decoys := []string{
+		"trusted_configs.json.tmp",
+		"trusted_configs.json.tmp-",
+		"trusted_configs.json.tmp-0",
+	}
+	for _, d := range decoys {
+		if err := os.Symlink(victim, filepath.Join(dir, d)); err != nil {
+			t.Fatalf("symlink %s: %v", d, err)
+		}
+	}
+
+	s := &TrustStore{path: filepath.Join(dir, "trusted_configs.json")}
+	if err := s.Add("/abs/foo", "sha"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	data, err := os.ReadFile(victim)
+	if err != nil {
+		t.Fatalf("read victim: %v", err)
+	}
+	if string(data) != "DO-NOT-OVERWRITE" {
+		t.Errorf("decoy symlink was followed: victim content = %q", data)
+	}
+	// Decoys themselves should remain as symlinks (untouched).
+	for _, d := range decoys {
+		info, err := os.Lstat(filepath.Join(dir, d))
+		if err != nil {
+			t.Errorf("decoy %s missing: %v", d, err)
+			continue
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			t.Errorf("decoy %s is no longer a symlink", d)
+		}
+	}
+
+	// Trust store itself was written correctly.
+	reloaded, err := LoadTrustStore(s.path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if !reloaded.IsTrusted("/abs/foo", "sha") {
+		t.Error("trust entry not persisted")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #105. A `.gwq.toml` in the current directory was merged into global viper on every subcommand, so `setup_commands` from a cloned repository auto-executed on the next `gwq add`. Malicious repos could use this for arbitrary code execution.

- Local config is now untrusted until the user explicitly accepts it. The decision is keyed by `(absolute path, SHA-256)` (direnv-style) and persisted to `~/.config/gwq/trusted_configs.json` (0600, atomic rename, symlink-guarded). A content change invalidates the decision and re-prompts.
- Hardening around the prompt itself: control bytes (C0/C1, CR, DEL) in the displayed file contents are escaped to `\xHH` so a hostile `.gwq.toml` cannot forge the `[y/N]` prompt via ANSI sequences; large files are truncated to 4 KiB; all prompt/warning output goes to stderr so shell integration that uses stdout as a protocol (`gwq cd`, completion) is not corrupted.
- Non-regular files (directory, FIFO) and non-TTY sessions are skipped with a stderr warning instead of prompting.

## Behavior matrix

| situation | outcome |
|---|---|
| no `.gwq.toml` | no disk read, no prompt (lazy load) |
| `.gwq.toml` already trusted (same hash) | silent merge |
| new `.gwq.toml` in TTY | prompt with sanitized contents; `y`/`yes` merges and persists |
| file content changed since last accept | re-prompt |
| deny (`n`, Enter, EOF) | stderr warning, file skipped, command continues |
| non-TTY / CI | stderr warning, file skipped, no prompt |
| non-regular file | stderr warning, file skipped |
| trust store path is a symlink | Add refuses to write, symlink target untouched |

## Non-goals

- `--yes` / `--force` flag for unattended trust (not added)
- `gwq config trust/untrust` management commands (not added; edit or delete the JSON to revoke)
- Walk-up discovery for `.gwq.toml` (still CWD only, unchanged)

## Test plan

- [x] `make test` — 501 tests pass including 93 new cases
- [x] `go test -race ./...` — clean
- [x] `make lint` — 0 issues
- [x] `go test -fuzz=FuzzLoadTrustStore -fuzztime=20s` — no crashes; property check: loaded entries are self-consistent with `IsTrusted`
- [x] Coverage: `internal/config/trust.go` averages 94.1%, `mergeLocalConfig` 84.2%, package total 81.2%
- [x] Manual E2E via tmux covering 9 scenarios: accept / silent re-run / file change re-prompt / deny / non-TTY skip / ANSI injection sanitization / 4 KiB truncation / malicious `setup_commands` blocked on non-TTY and on deny, executed on accept / non-regular file skip / trust store symlink rejection (target file preserved)