### PR TITLE
Release v0.1.0

### DIFF
--- a/docs/release-notes/v0.1.0.md
+++ b/docs/release-notes/v0.1.0.md
@@ -1,0 +1,51 @@
+# Release v0.1.0
+
+## 🔒 Security Fixes
+
+### Gate local `.gwq.toml` behind a trust prompt (#108)
+
+Fixes a privilege escalation vector where any `.gwq.toml` in the current working directory was merged into global configuration on every subcommand. A hostile repository could ship a `.gwq.toml` with `repository_settings.setup_commands` and silently run arbitrary code on the next `gwq add`.
+
+**New behavior:**
+
+- Local `.gwq.toml` is **untrusted** until you explicitly accept it. The prompt appears the first time gwq sees a given `(absolute path, SHA-256)` pair and is persisted to `~/.config/gwq/trusted_configs.json` (mode `0600`, atomic rename, symlink-guarded), direnv-style.
+- A content change to a previously-trusted `.gwq.toml` invalidates the decision and re-prompts.
+- Control bytes (C0/C1, CR, DEL) in the displayed file contents are escaped to `\xHH` so a hostile config cannot forge the `[y/N]` prompt via ANSI sequences. Large files are truncated to 4 KiB.
+- Prompt and warning output go to **stderr** so shell integration that uses stdout as a protocol (`gwq cd`, completion) is not corrupted.
+- Non-regular files (directory, FIFO) and non-TTY sessions are skipped with a stderr warning instead of prompting — existing CI and scripted usage with no `.gwq.toml` is unaffected.
+
+**Behavior matrix:**
+
+| situation                               | outcome                                                         |
+| --------------------------------------- | --------------------------------------------------------------- |
+| no `.gwq.toml`                          | no disk read, no prompt (lazy load)                             |
+| `.gwq.toml` already trusted (same hash) | silent merge                                                    |
+| new `.gwq.toml` in TTY                  | prompt with sanitized contents; `y` / `yes` merges and persists |
+| file content changed since last accept  | re-prompt                                                       |
+| deny (`n`, Enter, EOF)                  | stderr warning, file skipped, command continues                 |
+| non-TTY / CI                            | stderr warning, file skipped, no prompt                         |
+| non-regular file                        | stderr warning, file skipped                                    |
+| trust store path is a symlink           | gwq refuses to write; symlink target untouched                  |
+
+**To revoke trust** for a previously-accepted config, delete or edit `~/.config/gwq/trusted_configs.json`. A dedicated `gwq config trust/untrust` subcommand is not included in this release.
+
+## ⚠️ Breaking Changes
+
+- A `.gwq.toml` in the current directory is **no longer merged automatically**. The first time gwq sees one in an interactive shell, you must confirm at a `[y/N]` prompt. Users who relied on implicit merge (including `repository_settings.setup_commands`) will need to accept the prompt once per file-content version.
+- In non-TTY environments (CI, scripts, pipes), `.gwq.toml` is **never** merged and is skipped with a stderr warning. If you depended on local config in CI, move those settings to the global `~/.config/gwq/config.toml` or wire up trust explicitly by editing `~/.config/gwq/trusted_configs.json`.
+
+## 📦 Upgrade Instructions
+
+**Homebrew:**
+
+```bash
+brew upgrade d-kuro/tap/gwq
+```
+
+**Go:**
+
+```bash
+go install github.com/d-kuro/gwq/cmd/gwq@v0.1.0
+```
+
+**Full Changelog**: https://github.com/d-kuro/gwq/compare/v0.0.20...v0.1.0


### PR DESCRIPTION
## Summary

Release v0.1.0.

See `docs/release-notes/v0.1.0.md` for details.

Highlights:
- Security fix: local `.gwq.toml` is now gated behind an explicit trust prompt (#108)
- Breaking change: non-TTY environments no longer auto-merge `.gwq.toml`; interactive sessions require a one-time `[y/N]` confirm per file-content version.