### PR TITLE
feat: render template variables in setup_commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ repository = "~/src/myproject"
 copy_files = ["templates/.env.example", "config/*.json"]
 setup_commands = [
     "npm install",
-    'echo "worktree at {{.Path}}" > .gwq-setup.log',
+    'git config --local gwq.branch "{{.Branch}}"',
 ]
 basedir = "./worktrees"
 ```
@@ -394,8 +394,12 @@ Because commands go through `sh -c`, shell features like `~`, `&&`, pipes, and q
 
 ```toml
 setup_commands = [
-    'zellij action new-tab --name "{{.Branch}}" -- nvim .',
-    'ln -s "{{.Path}}/.memory" ~/memories/latest',
+    # Install dependencies in the new worktree
+    "npm install",
+    # Record which branch and commit this worktree was created from
+    'printf "branch=%s\npath=%s\n" "{{.Branch}}" "{{.Path}}" > .worktree-info',
+    # Launch your editor in the new worktree (replace $EDITOR as needed)
+    '$EDITOR "{{.Path}}" &',
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -371,8 +371,8 @@ Configure automatic file copying and setup commands per repository. These settin
 repository = "~/src/myproject"
 copy_files = ["templates/.env.example", "config/*.json"]
 setup_commands = [
-    "npm install",
-    'git config --local gwq.branch "{{.Branch}}"',
+    'echo "Created worktree for {{.Branch}}"',
+    'echo "{{.Branch}}" > .worktree-branch',
 ]
 basedir = "./worktrees"
 ```
@@ -394,12 +394,12 @@ Because commands go through `sh -c`, shell features like `~`, `&&`, pipes, and q
 
 ```toml
 setup_commands = [
-    # Install dependencies in the new worktree
-    "npm install",
-    # Record which branch and commit this worktree was created from
+    # Write metadata about the worktree to a local file
     'printf "branch=%s\npath=%s\n" "{{.Branch}}" "{{.Path}}" > .worktree-info',
-    # Launch your editor in the new worktree (replace $EDITOR as needed)
-    '$EDITOR "{{.Path}}" &',
+    # Create a per-worktree build directory (quote {{.Path}} in case it has spaces)
+    'mkdir -p "{{.Path}}/build"',
+    # Append a line to a history file so you can audit created worktrees
+    'echo "{{.Branch}} -> {{.Path}}" >> ~/.gwq-history',
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ Configure automatic file copying and setup commands per repository. These settin
 repository = "~/src/myproject"
 copy_files = ["templates/.env.example", "config/*.json"]
 setup_commands = [
-    'echo "Created worktree for {{.Branch}}"',
+    "npm install",
     'echo "{{.Branch}}" > .worktree-branch',
 ]
 basedir = "./worktrees"

--- a/README.md
+++ b/README.md
@@ -370,9 +370,40 @@ Configure automatic file copying and setup commands per repository. These settin
 [[repository_settings]]
 repository = "~/src/myproject"
 copy_files = ["templates/.env.example", "config/*.json"]
-setup_commands = ["npm install", "npm run setup"]
+setup_commands = [
+    "npm install",
+    'echo "worktree at {{.Path}}" > .gwq-setup.log',
+]
 basedir = "./worktrees"
 ```
+
+#### Template variables in `setup_commands`
+
+Each string in `setup_commands` is rendered with Go `text/template` and then executed via POSIX `sh -c`. Available variables:
+
+| Variable          | Example                                          |
+| ----------------- | ------------------------------------------------ |
+| `{{.Host}}`       | `github.com` (empty if no remote)                |
+| `{{.Owner}}`      | `d-kuro` (empty if no remote)                    |
+| `{{.Repository}}` | `gwq` (empty if no remote)                       |
+| `{{.Branch}}`     | `feature/new-ui` (raw, not filesystem-sanitized) |
+| `{{.Hash}}`       | `a1b2c3d4` (empty if no remote)                  |
+| `{{.Path}}`       | absolute worktree path                           |
+
+Because commands go through `sh -c`, shell features like `~`, `&&`, pipes, and quoting work. Template variables are substituted textually, so **quote them when the value may contain spaces or shell metacharacters**:
+
+```toml
+setup_commands = [
+    'zellij action new-tab --name "{{.Branch}}" -- nvim .',
+    'ln -s "{{.Path}}/.memory" ~/memories/latest',
+]
+```
+
+This matters most for `{{.Path}}` — worktree paths can contain spaces.
+
+Setup commands are a code-execution vector; local `.gwq.toml` files must be trusted before they run (see the trust prompt documentation).
+
+Unknown keys (e.g. `{{.Foo}}`) cause that command to be skipped with an error logged to stderr — they are not silently rendered as empty. Commands containing literal `{{` or `}}` must escape them using Go template syntax (`{{"{{"}}`), otherwise the template will fail to parse.
 
 #### Merge Behavior
 

--- a/internal/template/commands.go
+++ b/internal/template/commands.go
@@ -1,0 +1,44 @@
+package template
+
+import (
+	"fmt"
+	"strings"
+	"text/template"
+)
+
+// RenderedCommand is the outcome of rendering one setup command string.
+// On success, Rendered holds the expanded command and Err is nil.
+// On failure, Err is non-nil and Rendered is empty — callers MUST skip
+// the command, never fall back to Source (a literal "{{ ... }}" would
+// otherwise leak into the shell).
+type RenderedCommand struct {
+	Source   string
+	Rendered string
+	Err      error
+}
+
+// RenderCommands parses and executes each command string as a Go text/template
+// with the given data. Commands are rendered independently; a failure on one
+// command does not short-circuit the rest. Unknown keys are reported as errors
+// thanks to the "missingkey=error" option.
+func RenderCommands(commands []string, data *TemplateData) []RenderedCommand {
+	results := make([]RenderedCommand, 0, len(commands))
+	for _, src := range commands {
+		results = append(results, renderOne(src, data))
+	}
+	return results
+}
+
+func renderOne(src string, data *TemplateData) RenderedCommand {
+	tmpl, err := template.New("setup_command").Option("missingkey=error").Parse(src)
+	if err != nil {
+		return RenderedCommand{Source: src, Err: fmt.Errorf("parse command %q: %w", src, err)}
+	}
+
+	var buf strings.Builder
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return RenderedCommand{Source: src, Err: fmt.Errorf("execute template %q: %w", src, err)}
+	}
+
+	return RenderedCommand{Source: src, Rendered: buf.String()}
+}

--- a/internal/template/commands_test.go
+++ b/internal/template/commands_test.go
@@ -1,0 +1,99 @@
+package template
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderCommands(t *testing.T) {
+	data := &TemplateData{
+		Host:       "github.com",
+		Owner:      "d-kuro",
+		Repository: "gwq",
+		Branch:     "feature/new-ui",
+		Hash:       "a1b2c3d4",
+		Path:       "/tmp/worktrees/gwq/feature-new-ui",
+	}
+
+	tests := []struct {
+		name          string
+		commands      []string
+		wantRendered  []string // expected Rendered for each input index; "" means expect Err
+		wantErrSubstr []string // expected substring in Err for each input index; "" means expect no Err
+	}{
+		{
+			name: "all variables render",
+			commands: []string{
+				"echo {{.Branch}} {{.Path}}",
+				"zellij action new-tab --name {{.Branch}} -- nvim .",
+				"mkdir -p {{.Path}}/.local",
+			},
+			wantRendered: []string{
+				"echo feature/new-ui /tmp/worktrees/gwq/feature-new-ui",
+				"zellij action new-tab --name feature/new-ui -- nvim .",
+				"mkdir -p /tmp/worktrees/gwq/feature-new-ui/.local",
+			},
+			wantErrSubstr: []string{"", "", ""},
+		},
+		{
+			name:          "parse error is captured per command",
+			commands:      []string{"echo {{.Branch}}", "echo {{ invalid"},
+			wantRendered:  []string{"echo feature/new-ui", ""},
+			wantErrSubstr: []string{"", "parse command"},
+		},
+		{
+			name:          "missing key is an error (missingkey=error)",
+			commands:      []string{"echo {{.NoSuchVar}}"},
+			wantRendered:  []string{""},
+			wantErrSubstr: []string{"execute template"},
+		},
+		{
+			name:          "empty input is a no-op",
+			commands:      []string{},
+			wantRendered:  []string{},
+			wantErrSubstr: []string{},
+		},
+		{
+			name:          "first failure does not short-circuit subsequent commands",
+			commands:      []string{"echo {{.NoSuchVar}}", "echo {{.Branch}}", "echo {{.Path}}"},
+			wantRendered:  []string{"", "echo feature/new-ui", "echo /tmp/worktrees/gwq/feature-new-ui"},
+			wantErrSubstr: []string{"execute template", "", ""},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := RenderCommands(tc.commands, data)
+
+			if len(got) != len(tc.commands) {
+				t.Fatalf("len mismatch: got %d results for %d commands", len(got), len(tc.commands))
+			}
+
+			for i, rc := range got {
+				if rc.Source != tc.commands[i] {
+					t.Errorf("index %d: Source = %q; want %q", i, rc.Source, tc.commands[i])
+				}
+
+				wantErr := tc.wantErrSubstr[i] != ""
+				if wantErr {
+					if rc.Err == nil {
+						t.Errorf("index %d: expected error containing %q, got nil", i, tc.wantErrSubstr[i])
+					} else if !strings.Contains(rc.Err.Error(), tc.wantErrSubstr[i]) {
+						t.Errorf("index %d: error %q does not contain %q", i, rc.Err.Error(), tc.wantErrSubstr[i])
+					}
+					if rc.Rendered != "" {
+						t.Errorf("index %d: Rendered should be empty on error, got %q", i, rc.Rendered)
+					}
+					continue
+				}
+
+				if rc.Err != nil {
+					t.Errorf("index %d: unexpected error: %v", i, rc.Err)
+				}
+				if rc.Rendered != tc.wantRendered[i] {
+					t.Errorf("index %d: Rendered = %q; want %q", i, rc.Rendered, tc.wantRendered[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -19,6 +19,7 @@ type TemplateData struct {
 	Repository string // e.g., "myapp"
 	Branch     string // e.g., "feature/new-ui"
 	Hash       string // Short hash of the repository URL + branch
+	Path       string // Absolute worktree path (empty while rendering naming.template)
 }
 
 // Processor handles template processing for worktree path generation.
@@ -88,4 +89,11 @@ func (p *Processor) sanitizeBranch(branch string) string {
 func generateShortHash(input string) string {
 	hash := sha256.Sum256([]byte(input))
 	return fmt.Sprintf("%x", hash[:4]) // 8 character hex string
+}
+
+// ShortHash returns the 8-character short hash used to disambiguate worktrees.
+// Callers outside this package (e.g. setup_commands template data) share this
+// helper so the hash formula stays in one place.
+func ShortHash(input string) string {
+	return generateShortHash(input)
 }

--- a/internal/worktree/post_setup.go
+++ b/internal/worktree/post_setup.go
@@ -7,47 +7,92 @@ import (
 
 	"github.com/d-kuro/gwq/internal/command"
 	"github.com/d-kuro/gwq/internal/filesystem"
+	"github.com/d-kuro/gwq/internal/template"
+	"github.com/d-kuro/gwq/internal/url"
 	"github.com/d-kuro/gwq/internal/utils"
 	"github.com/d-kuro/gwq/pkg/models"
 )
 
 // runPostWorktreeSetup runs file copy and setup commands for the new worktree.
-func (m *Manager) runPostWorktreeSetup(worktreePath string) {
+// branch is used as the raw value for {{.Branch}} in templated setup commands.
+func (m *Manager) runPostWorktreeSetup(branch, worktreePath string) {
+	m.runPostWorktreeSetupWithExecutor(context.Background(), command.NewStandardExecutor(), branch, worktreePath)
+}
+
+// runPostWorktreeSetupWithExecutor is the test seam for runPostWorktreeSetup.
+// It returns the SetupResult slice so tests can assert on per-command outcomes.
+func (m *Manager) runPostWorktreeSetupWithExecutor(ctx context.Context, executor Executor, branch, worktreePath string) []SetupResult {
 	if len(m.config.RepositorySettings) == 0 {
-		return
+		return nil
 	}
 
 	repoRoot, err := m.git.GetMainRepositoryPath()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[gwq] warning: failed to get repository path: %v\n", err)
-		return
+		return nil
 	}
 
 	repoSetting := findRepoSetting(m.config.RepositorySettings, repoRoot)
 	if repoSetting == nil {
-		return
+		return nil
 	}
 
-	// Copy files
 	for _, err := range CopyFilesWithGlob(filesystem.NewStandardFileSystem(), repoRoot, worktreePath, repoSetting.CopyFiles) {
 		fmt.Fprintf(os.Stderr, "[gwq] file copy error: %v\n", err)
 	}
 
-	// Run setup commands
-	outputs, setupErrs := RunSetupCommands(
-		context.Background(),
-		command.NewStandardExecutor(),
-		worktreePath,
-		repoSetting.SetupCommands,
-	)
-	for i, out := range outputs {
-		if out != "" {
-			fmt.Fprintf(os.Stderr, "[gwq] setup command output: %s\n", out)
+	data := buildSetupTemplateData(m.git, branch, worktreePath)
+	rendered := template.RenderCommands(repoSetting.SetupCommands, data)
+
+	toRun := make([]string, 0, len(rendered))
+	for _, rc := range rendered {
+		if rc.Err != nil {
+			fmt.Fprintf(os.Stderr, "[gwq] setup command template error: %v\n", rc.Err)
+			continue
 		}
-		if i < len(setupErrs) && setupErrs[i] != nil {
-			fmt.Fprintf(os.Stderr, "[gwq] setup command error: %v\n", setupErrs[i])
+		toRun = append(toRun, rc.Rendered)
+	}
+
+	results := RunSetupCommands(ctx, executor, worktreePath, toRun)
+	for _, r := range results {
+		if r.Output != "" {
+			fmt.Fprintf(os.Stderr, "[gwq] setup command output: %s\n", r.Output)
+		}
+		if r.Err != nil {
+			fmt.Fprintf(os.Stderr, "[gwq] setup command error: %s: %v\n", r.Command, r.Err)
 		}
 	}
+
+	return results
+}
+
+// buildSetupTemplateData assembles the data for rendering setup commands.
+// When the repository has no resolvable origin URL, Host/Owner/Repository/Hash
+// are left empty and a warning is logged — commands that only reference
+// {{.Branch}} / {{.Path}} still work.
+func buildSetupTemplateData(git GitInterface, branch, worktreePath string) *template.TemplateData {
+	data := &template.TemplateData{
+		Branch: branch,
+		Path:   worktreePath,
+	}
+
+	repoURL, err := git.GetRepositoryURL()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[gwq] warning: origin URL unavailable, Host/Owner/Repository/Hash will be empty: %v\n", err)
+		return data
+	}
+
+	repoInfo, err := url.ParseRepositoryURL(repoURL)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[gwq] warning: failed to parse repository URL %q: %v\n", repoURL, err)
+		return data
+	}
+
+	data.Host = repoInfo.Host
+	data.Owner = repoInfo.Owner
+	data.Repository = repoInfo.Repository
+	data.Hash = template.ShortHash(repoInfo.FullPath + "/" + branch)
+	return data
 }
 
 // findRepoSetting returns the first matching RepositorySetting for the given repo root.

--- a/internal/worktree/post_setup_test.go
+++ b/internal/worktree/post_setup_test.go
@@ -1,0 +1,160 @@
+package worktree
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/d-kuro/gwq/pkg/models"
+)
+
+// recordingExecutor records every Execute call so we can assert the exact
+// rendered command string passed to `sh -c`.
+type recordingExecutor struct {
+	fakeExecutor
+}
+
+func newRecordingExecutor() *recordingExecutor {
+	return &recordingExecutor{}
+}
+
+func (r *recordingExecutor) rendered() []string {
+	out := make([]string, 0, len(r.calls))
+	for _, c := range r.calls {
+		// args layout is always ["-c", "<rendered cmd>"]
+		if len(c.args) == 2 && c.args[0] == "-c" {
+			out = append(out, c.args[1])
+		}
+	}
+	return out
+}
+
+func buildManagerWithRepoSetting(g *mockGit, setting models.RepositorySetting) *Manager {
+	cfg := &models.Config{
+		RepositorySettings: []models.RepositorySetting{setting},
+	}
+	return &Manager{git: g, config: cfg}
+}
+
+func TestRunPostWorktreeSetup_RendersTemplateVariables(t *testing.T) {
+	git := &mockGit{
+		repoPath: "/mock/repo/path",
+		repoURL:  "https://github.com/test-user/test-repo.git",
+	}
+	setting := models.RepositorySetting{
+		Repository: "/mock/repo/path",
+		SetupCommands: []string{
+			"echo branch={{.Branch}} path={{.Path}}",
+			"echo host={{.Host}} owner={{.Owner}} repo={{.Repository}}",
+		},
+	}
+	m := buildManagerWithRepoSetting(git, setting)
+
+	exec := newRecordingExecutor()
+	results := m.runPostWorktreeSetupWithExecutor(context.Background(), exec, "feature/new-ui", "/tmp/worktrees/gwq/feature-new-ui")
+
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+
+	got := exec.rendered()
+	wantContains := []string{
+		"branch=feature/new-ui path=/tmp/worktrees/gwq/feature-new-ui",
+		"host=github.com owner=test-user repo=test-repo",
+	}
+	for i, w := range wantContains {
+		if i >= len(got) {
+			t.Fatalf("missing rendered command at index %d", i)
+		}
+		if !strings.Contains(got[i], w) {
+			t.Errorf("rendered[%d] = %q; want it to contain %q", i, got[i], w)
+		}
+	}
+}
+
+func TestRunPostWorktreeSetup_FallbackWhenRemoteUnavailable(t *testing.T) {
+	git := &mockGit{
+		repoPath:     "/mock/repo/path",
+		repoURLError: errors.New("no origin remote"),
+	}
+	setting := models.RepositorySetting{
+		Repository: "/mock/repo/path",
+		SetupCommands: []string{
+			"echo branch={{.Branch}} path={{.Path}} host=[{{.Host}}]",
+		},
+	}
+	m := buildManagerWithRepoSetting(git, setting)
+
+	exec := newRecordingExecutor()
+	results := m.runPostWorktreeSetupWithExecutor(context.Background(), exec, "topic", "/wt/topic")
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	got := exec.rendered()
+	if len(got) != 1 {
+		t.Fatalf("expected 1 rendered call, got %d", len(got))
+	}
+	if !strings.Contains(got[0], "branch=topic") {
+		t.Errorf("rendered = %q; missing branch=topic", got[0])
+	}
+	if !strings.Contains(got[0], "path=/wt/topic") {
+		t.Errorf("rendered = %q; missing path=/wt/topic", got[0])
+	}
+	if !strings.Contains(got[0], "host=[]") {
+		t.Errorf("rendered = %q; Host should be empty when remote is unavailable", got[0])
+	}
+}
+
+func TestRunPostWorktreeSetup_TemplateErrorSkipsOnlyFailing(t *testing.T) {
+	git := &mockGit{
+		repoPath: "/mock/repo/path",
+		repoURL:  "https://github.com/test-user/test-repo.git",
+	}
+	setting := models.RepositorySetting{
+		Repository: "/mock/repo/path",
+		SetupCommands: []string{
+			"echo ok {{.Branch}}",
+			"echo bad {{.NoSuchVar}}",
+			"echo also ok {{.Path}}",
+		},
+	}
+	m := buildManagerWithRepoSetting(git, setting)
+
+	exec := newRecordingExecutor()
+	results := m.runPostWorktreeSetupWithExecutor(context.Background(), exec, "br", "/wt/br")
+
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results (bad skipped), got %d", len(results))
+	}
+	got := exec.rendered()
+	if len(got) != 2 {
+		t.Fatalf("expected 2 executor calls, got %d", len(got))
+	}
+	if !strings.Contains(got[0], "ok br") {
+		t.Errorf("rendered[0] = %q; want contains \"ok br\"", got[0])
+	}
+	if !strings.Contains(got[1], "also ok /wt/br") {
+		t.Errorf("rendered[1] = %q; want contains \"also ok /wt/br\"", got[1])
+	}
+}
+
+func TestRunPostWorktreeSetup_NoMatchingRepoSetting(t *testing.T) {
+	git := &mockGit{repoPath: "/mock/repo/path"}
+	setting := models.RepositorySetting{
+		Repository:    "/different/repo",
+		SetupCommands: []string{"echo should-not-run"},
+	}
+	m := buildManagerWithRepoSetting(git, setting)
+
+	exec := newRecordingExecutor()
+	results := m.runPostWorktreeSetupWithExecutor(context.Background(), exec, "br", "/wt/br")
+
+	if len(results) != 0 {
+		t.Errorf("expected no results when repo does not match, got %d", len(results))
+	}
+	if len(exec.calls) != 0 {
+		t.Errorf("expected no executor calls, got %d", len(exec.calls))
+	}
+}

--- a/internal/worktree/setup_commands.go
+++ b/internal/worktree/setup_commands.go
@@ -2,33 +2,36 @@ package worktree
 
 import (
 	"context"
-	"fmt"
 	"strings"
 )
 
-// RunSetupCommands executes each command in the given directory using the provided executor.
-// It returns a slice of errors (one per failed command, if any), and a slice of outputs (stdout+stderr per command).
-func RunSetupCommands(ctx context.Context, executor interface {
+// Executor is the minimal contract needed to run a setup command.
+// command.NewStandardExecutor() satisfies it; tests supply fakes.
+type Executor interface {
 	ExecuteInDirWithOutput(ctx context.Context, dir, name string, args ...string) (string, error)
-}, dir string, commands []string) (outputs []string, errs []error) {
+}
+
+// SetupResult is the outcome of running one setup command. Each field is
+// self-contained so callers do not need to correlate parallel output/error
+// slices by index.
+type SetupResult struct {
+	Command string
+	Output  string
+	Err     error
+}
+
+// RunSetupCommands runs each non-empty command string via `sh -c` in the
+// given directory. It returns one SetupResult per command actually executed
+// (empty or whitespace-only commands are skipped silently).
+func RunSetupCommands(ctx context.Context, executor Executor, dir string, commands []string) []SetupResult {
+	results := make([]SetupResult, 0, len(commands))
 	for _, cmd := range commands {
-		cmd = strings.TrimSpace(cmd)
-		if cmd == "" {
+		trimmed := strings.TrimSpace(cmd)
+		if trimmed == "" {
 			continue
 		}
-
-		parts := strings.Fields(cmd)
-		if len(parts) == 0 {
-			continue
-		}
-
-		name := parts[0]
-		args := parts[1:]
-		output, err := executor.ExecuteInDirWithOutput(ctx, dir, name, args...)
-		outputs = append(outputs, output)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("%s: %w", cmd, err))
-		}
+		output, err := executor.ExecuteInDirWithOutput(ctx, dir, "sh", "-c", trimmed)
+		results = append(results, SetupResult{Command: trimmed, Output: output, Err: err})
 	}
-	return outputs, errs
+	return results
 }

--- a/internal/worktree/setup_commands_test.go
+++ b/internal/worktree/setup_commands_test.go
@@ -3,49 +3,133 @@ package worktree
 import (
 	"context"
 	"errors"
-	"path/filepath"
+	"reflect"
 	"testing"
 )
 
+// capturedCall records one invocation of the fake Executor.
+type capturedCall struct {
+	dir  string
+	name string
+	args []string
+}
+
+// fakeExecutor implements the Executor interface. Tests use it to assert the
+// exact name/args passed through from RunSetupCommands.
 type fakeExecutor struct {
-	calls   []string
+	calls   []capturedCall
 	outputs []string
 	errs    []error
 }
 
-func (f *fakeExecutor) ExecuteInDirWithOutput(ctx context.Context, dir, name string, args ...string) (string, error) {
-	f.calls = append(f.calls, filepath.Join(dir, name+" "+filepath.Join(args...)))
+var _ Executor = (*fakeExecutor)(nil)
 
+func (f *fakeExecutor) ExecuteInDirWithOutput(_ context.Context, dir, name string, args ...string) (string, error) {
+	f.calls = append(f.calls, capturedCall{dir: dir, name: name, args: append([]string(nil), args...)})
+
+	var out string
 	if len(f.outputs) > 0 {
-		out := f.outputs[0]
+		out = f.outputs[0]
 		f.outputs = f.outputs[1:]
-
-		var err error
-		if len(f.errs) > 0 {
-			err = f.errs[0]
-			f.errs = f.errs[1:]
-		}
-
-		return out, err
 	}
 
-	return "", nil
+	var err error
+	if len(f.errs) > 0 {
+		err = f.errs[0]
+		f.errs = f.errs[1:]
+	}
+
+	return out, err
 }
 
-func TestRunSetupCommands(t *testing.T) {
+func TestRunSetupCommands_ShellInvocation(t *testing.T) {
 	exec := &fakeExecutor{
 		outputs: []string{"ok1", "ok2"},
 		errs:    []error{nil, errors.New("fail")},
 	}
 	dir := t.TempDir()
 	ctx := context.Background()
-	cmds := []string{"echo foo", "failcmd bar"}
-
-	outputs, errs := RunSetupCommands(ctx, exec, dir, cmds)
-	if len(outputs) != 2 {
-		t.Errorf("expected 2 outputs, got %d", len(outputs))
+	cmds := []string{
+		"echo \"hello world\"",
+		"ln -s ~/foo bar && touch baz",
 	}
-	if len(errs) != 1 {
-		t.Errorf("expected 1 error, got %d", len(errs))
+
+	results := RunSetupCommands(ctx, exec, dir, cmds)
+
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+
+	for i, want := range cmds {
+		call := exec.calls[i]
+		if call.dir != dir {
+			t.Errorf("index %d: dir = %q; want %q", i, call.dir, dir)
+		}
+		if call.name != "sh" {
+			t.Errorf("index %d: name = %q; want \"sh\"", i, call.name)
+		}
+		wantArgs := []string{"-c", want}
+		if !reflect.DeepEqual(call.args, wantArgs) {
+			t.Errorf("index %d: args = %v; want %v", i, call.args, wantArgs)
+		}
+	}
+
+	if results[0].Err != nil {
+		t.Errorf("results[0].Err = %v; want nil", results[0].Err)
+	}
+	if results[0].Output != "ok1" {
+		t.Errorf("results[0].Output = %q; want \"ok1\"", results[0].Output)
+	}
+	if results[0].Command != cmds[0] {
+		t.Errorf("results[0].Command = %q; want %q", results[0].Command, cmds[0])
+	}
+	if results[1].Err == nil {
+		t.Errorf("results[1].Err = nil; want non-nil")
+	}
+	if results[1].Output != "ok2" {
+		t.Errorf("results[1].Output = %q; want \"ok2\"", results[1].Output)
+	}
+}
+
+func TestRunSetupCommands_SkipEmpty(t *testing.T) {
+	exec := &fakeExecutor{}
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	results := RunSetupCommands(ctx, exec, dir, []string{"", "   ", "echo hi", "\t\n"})
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result after skipping empties, got %d", len(results))
+	}
+	if results[0].Command != "echo hi" {
+		t.Errorf("results[0].Command = %q; want \"echo hi\"", results[0].Command)
+	}
+	if len(exec.calls) != 1 {
+		t.Errorf("expected 1 executor call, got %d", len(exec.calls))
+	}
+}
+
+func TestRunSetupCommands_IndexAlignment(t *testing.T) {
+	// Regression: the legacy implementation appended to errs only on failure,
+	// so outputs[i] and errs[i] drifted. The new []SetupResult shape gives
+	// each command a self-contained entry, even when earlier ones succeeded.
+	exec := &fakeExecutor{
+		outputs: []string{"o1", "o2", "o3"},
+		errs:    []error{nil, errors.New("boom"), nil},
+	}
+	ctx := context.Background()
+	results := RunSetupCommands(ctx, exec, "/dir", []string{"a", "b", "c"})
+
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(results))
+	}
+	if results[0].Err != nil || results[0].Output != "o1" || results[0].Command != "a" {
+		t.Errorf("result 0 = %+v; want {Command: a, Output: o1, Err: nil}", results[0])
+	}
+	if results[1].Err == nil || results[1].Output != "o2" || results[1].Command != "b" {
+		t.Errorf("result 1 = %+v; want {Command: b, Output: o2, Err: non-nil}", results[1])
+	}
+	if results[2].Err != nil || results[2].Output != "o3" || results[2].Command != "c" {
+		t.Errorf("result 2 = %+v; want {Command: c, Output: o3, Err: nil}", results[2])
 	}
 }

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -52,7 +52,7 @@ func (m *Manager) Add(branch string, customPath string, createBranch bool) (stri
 		return "", err
 	}
 
-	m.runPostWorktreeSetup(path)
+	m.runPostWorktreeSetup(branch, path)
 	return path, nil
 }
 
@@ -68,7 +68,7 @@ func (m *Manager) AddFromBase(branch string, baseBranch string, customPath strin
 		return "", err
 	}
 
-	m.runPostWorktreeSetup(path)
+	m.runPostWorktreeSetup(branch, path)
 	return path, nil
 }
 

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -15,6 +15,8 @@ type mockGit struct {
 	worktrees         []models.Worktree
 	repoName          string
 	repoPath          string
+	repoURL           string
+	repoURLError      error
 	addError          error
 	removeError       error
 	listError         error
@@ -72,6 +74,12 @@ func (m *mockGit) GetRecentCommits(path string, limit int) ([]models.CommitInfo,
 }
 
 func (m *mockGit) GetRepositoryURL() (string, error) {
+	if m.repoURLError != nil {
+		return "", m.repoURLError
+	}
+	if m.repoURL != "" {
+		return m.repoURL, nil
+	}
 	return "https://github.com/test-user/test-repo.git", nil
 }
 


### PR DESCRIPTION
## Summary

- `{{.Branch}}`, `{{.Path}}`, `{{.Host}}`, `{{.Owner}}`, `{{.Repository}}` and `{{.Hash}}` now expand inside every string in `[[repository_settings]].setup_commands`. `{{.Path}}` is newly introduced; the others already existed for `naming.template` and are now available here too.
- Each command runs through POSIX `sh -c`, so `~`, `&&`, pipes, `$()` and quoting work as written.
- Commands that reference an unknown key are skipped with a `[gwq] setup command template error: ...` line on stderr — they never reach the shell as literal `{{ ... }}`.
- When the repository has no resolvable origin, `{{.Branch}}` / `{{.Path}}` still render and the remote-derived fields (`Host` / `Owner` / `Repository` / `Hash`) stay empty.
- Publishes `worktree.Executor` as a named interface and returns `[]SetupResult` from `RunSetupCommands`, which incidentally fixes a latent index-drift bug in the previous parallel `outputs` / `errs` slices.

Closes #106.

## Breaking changes

1. `setup_commands` entries are no longer tokenised with `strings.Fields`; each entry is now a shell command. Configs that relied on literal `*`, unescaped quotes or whitespace-split argv semantics need to be adjusted (and, in many cases, simply work now that the shell handles them).
2. `setup_commands` strings go through `text/template`. Literal `{{` or `}}` must be escaped using Go template syntax (`{{"{{"}}`), otherwise the command fails to parse and is skipped.

## Test plan

- [x] `make test` — full suite (including new `commands_test.go`, updated `setup_commands_test.go`, and new `post_setup_test.go`)
- [x] `make lint` — `0 issues`
- [x] E2E against scratch repositories (tmux/expect driven):
  - All six variables render; `sh -c` features (`$()`, `&&`, `ln -s`) work; unknown-key command is skipped with a stderr warning; subsequent commands still execute (no index drift).
  - No-origin fallback: `{{.Branch}}` / `{{.Path}}` render, `{{.Host}}` renders as empty.
  - Interactive trust prompt accepts `y` through a real PTY and setup commands run.