### PR TITLE
Release v0.1.1

### DIFF
--- a/docs/release-notes/v0.1.1.md
+++ b/docs/release-notes/v0.1.1.md
@@ -1,0 +1,58 @@
+# Release v0.1.1
+
+## 🎉 New Features
+
+### Template variables in `setup_commands` (#110)
+
+Each string in `[[repository_settings]].setup_commands` is now rendered with Go `text/template` before being executed via POSIX `sh -c`. Available variables:
+
+| Variable          | Example                                          |
+| ----------------- | ------------------------------------------------ |
+| `{{.Host}}`       | `github.com` (empty if no remote)                |
+| `{{.Owner}}`      | `d-kuro` (empty if no remote)                    |
+| `{{.Repository}}` | `gwq` (empty if no remote)                       |
+| `{{.Branch}}`     | `feature/new-ui` (raw, not filesystem-sanitized) |
+| `{{.Hash}}`       | `a1b2c3d4` (empty if no remote)                  |
+| `{{.Path}}`       | absolute worktree path                           |
+
+`{{.Path}}` is new; the others are the same set that `naming.template` already recognized.
+
+Because each entry is shelled out through `sh -c`, familiar shell features (`~` expansion, `&&`, pipes, command substitution, quoting) now work without a wrapper:
+
+```toml
+[[repository_settings]]
+repository = "~/src/myproject"
+setup_commands = [
+    # Write metadata about the worktree to a local file
+    'printf "branch=%s\npath=%s\n" "{{.Branch}}" "{{.Path}}" > .worktree-info',
+    # Create a per-worktree build directory (quote {{.Path}} in case it has spaces)
+    'mkdir -p "{{.Path}}/build"',
+    # Append a line to a history file so you can audit created worktrees
+    'echo "{{.Branch}} -> {{.Path}}" >> ~/.gwq-history',
+]
+```
+
+Commands that reference an unknown key (e.g. `{{.Typo}}`) are skipped with a `[gwq] setup command template error: ...` warning on stderr — they are never passed to the shell with a literal `{{ ... }}` in them. When the repository has no resolvable origin, `{{.Branch}}` and `{{.Path}}` still render and the remote-derived fields remain empty so commands depending only on those two variables keep working.
+
+Closes #106.
+
+## ⚠️ Breaking Changes
+
+1. `setup_commands` entries are no longer tokenized with `strings.Fields` and passed to `exec.Command`; each entry is now executed with `sh -c`. Configs that relied on whitespace-split argv semantics, unescaped shell metacharacters, or literal `*` (which would have been passed verbatim before) may behave differently and should be quoted as regular shell commands.
+2. `setup_commands` strings pass through `text/template`. Commands that contain literal `{{` or `}}` must escape them using Go template syntax (`{{"{{"}}`), otherwise the template will fail to parse and the command will be skipped.
+
+## 📦 Upgrade Instructions
+
+**Homebrew:**
+
+```bash
+brew upgrade d-kuro/tap/gwq
+```
+
+**Go:**
+
+```bash
+go install github.com/d-kuro/gwq/cmd/gwq@v0.1.1
+```
+
+**Full Changelog**: https://github.com/d-kuro/gwq/compare/v0.1.0...v0.1.1


### PR DESCRIPTION
## Summary

Release v0.1.1

See `docs/release-notes/v0.1.1.md` for details.