### PR TITLE
feat: support recursively copying directories matching glob patterns

### DIFF
--- a/internal/worktree/copy_files.go
+++ b/internal/worktree/copy_files.go
@@ -39,11 +39,43 @@ func copyFilesForPattern(fs filesystem.FileSystemInterface, srcRoot, dstRoot, pa
 			continue
 		}
 		if info.IsDir() {
+			errs = append(errs, copyDirectory(fs, srcRoot, dstRoot, srcPath)...)
 			continue
 		}
 
 		if err := copySingleFile(fs, srcRoot, dstRoot, srcPath); err != nil {
 			errs = append(errs, err)
+		}
+	}
+
+	return errs
+}
+
+// copyDirectory recursively copies a directory and its contents.
+func copyDirectory(fs filesystem.FileSystemInterface, srcRoot, dstRoot, srcDir string) []error {
+	var errs []error
+
+	entries, err := fs.ReadDir(srcDir)
+	if err != nil {
+		return []error{fmt.Errorf("read directory %q: %w", srcDir, err)}
+	}
+
+	relPath, err := filepath.Rel(srcRoot, srcDir)
+	if err == nil {
+		dstPath := filepath.Join(dstRoot, relPath)
+		if err := fs.MkdirAll(dstPath, 0755); err != nil {
+			errs = append(errs, fmt.Errorf("create directory for %q: %w", dstPath, err))
+		}
+	}
+
+	for _, entry := range entries {
+		path := filepath.Join(srcDir, entry.Name())
+		if entry.IsDir() {
+			errs = append(errs, copyDirectory(fs, srcRoot, dstRoot, path)...)
+		} else {
+			if err := copySingleFile(fs, srcRoot, dstRoot, path); err != nil {
+				errs = append(errs, err)
+			}
 		}
 	}
 

--- a/internal/worktree/copy_files_test.go
+++ b/internal/worktree/copy_files_test.go
@@ -67,6 +67,19 @@ func TestCopyFilesWithGlob(t *testing.T) {
 			},
 			notExpected: []string{"templates/README.md", "src/main.go"},
 		},
+		{
+			name: "copy directory",
+			dirs: []string{"versions/1.20/run/config", "versions/1.20/run/logs"},
+			files: map[string]string{
+				"versions/1.20/run/config/settings.json": "settings",
+				"versions/1.20/run/eula.txt":             "eula",
+			},
+			patterns: []string{"versions/*/run"},
+			expected: []string{
+				"versions/1.20/run/config/settings.json",
+				"versions/1.20/run/eula.txt",
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes #112 

## Description

This PR enhances the `copy_files` functionality to support recursively copying directories.

Previously, if a glob pattern in `copy_files` matched a directory, `gwq` would skip it completely because of the `if info.IsDir() { continue }` check. 
With this change, `gwq` will instead:
- Create the matching directory structure in the destination worktree.
- Recursively copy all files and subdirectories contained within.

This is particularly useful when users want to replicate entire configuration folders (e.g., `versions/*/run`) or environment structures into new worktrees.

## Changes
- Modified `copyFilesForPattern` to call a new `copyDirectory` function instead of skipping directories.
- Implemented `copyDirectory` which recursively walks through directory contents using the abstract `FileSystemInterface`.
- Added a new unit test in `copy_files_test.go` to ensure directories and their contents are successfully copied.

## Testing
- [x] Tested locally with `go test ./...`
- [x] Verified that nested directory contents are correctly recreated in the target worktree.
